### PR TITLE
fix: P1 review blockers + marketplace installer + README rewrite

### DIFF
--- a/claude-code/install.ps1
+++ b/claude-code/install.ps1
@@ -17,6 +17,7 @@ $ErrorActionPreference = "Stop"
 
 $MarketplaceGitUrl = "https://github.com/ttttstc/vibeflow.git"
 $MarketplaceName = "vibeflow"
+$RepoName = "ttttstc/vibeflow"
 
 # =============================================================================
 # Paths
@@ -31,65 +32,54 @@ $KnownMarketplacesFile = Join-Path $ClaudePluginsDir "known_marketplaces.json"
 # Helper Functions
 # =============================================================================
 
-function Write-Info { param($Message) Write-Host "ℹ " -ForegroundColor Blue -NoNewline; Write-Host $Message }
-function Write-Success { param($Message) Write-Host "✓ " -ForegroundColor Green -NoNewline; Write-Host $Message }
-
-function Format-Json {
-    param([string]$json)
-    $indent = 0
-    $result = [System.Text.StringBuilder]::new()
-    $inString = $false
-    for ($i = 0; $i -lt $json.Length; $i++) {
-        $char = $json[$i]
-        switch ($char) {
-            '"'     { $inString = -not $inString; [void]$result.Append($char) }
-            '{'     { [void]$result.Append($char); if (-not $inString) { $indent++; [void]$result.Append("`n" + ('  ' * $indent)) } }
-            '}'     { if (-not $inString) { $indent--; [void]$result.Append("`n" + ('  ' * $indent)) }; [void]$result.Append($char) }
-            ','     { [void]$result.Append($char); if (-not $inString) { [void]$result.Append("`n" + ('  ' * $indent)) } }
-            ':'     { [void]$result.Append($char); if (-not $inString) { [void]$result.Append(' ') } }
-            '['     { [void]$result.Append($char); if (-not $inString) { $indent++; [void]$result.Append("`n" + ('  ' * $indent)) } }
-            ']'     { if (-not $inString) { $indent--; [void]$result.Append("`n" + ('  ' * $indent)) }; [void]$result.Append($char) }
-            default { [void]$result.Append($char) }
-        }
-    }
-    return $result.ToString()
-}
+function Write-Info { param($Message) Write-Host "INFO: $Message" }
+function Write-Success { param($Message) Write-Host "SUCCESS: $Message" }
+function Write-Err { param($Message) Write-Host "ERROR: $Message" -ForegroundColor Red }
 
 # =============================================================================
 # Pre-flight Check
 # =============================================================================
 
 if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
-    Write-Host "Error: git is not installed" -ForegroundColor Red
+    Write-Err "git is not installed"
     exit 1
 }
 
+Write-Info "Installing vibeflow marketplace..."
+
 # =============================================================================
-# Install
+# Clone or Update
 # =============================================================================
 
-Write-Info "Installing marketplace: $MarketplaceName"
-
-# Remove existing if present
-if (Test-Path $TargetDir) {
-    Write-Info "Removing existing installation..."
-    Remove-Item $TargetDir -Recurse -Force
-}
-
-# Clone repository
-Write-Info "Cloning from: $MarketplaceGitUrl"
 if (-not (Test-Path $MarketplacesDir)) {
     New-Item -ItemType Directory -Force -Path $MarketplacesDir | Out-Null
 }
 
-git clone --depth 1 $MarketplaceGitUrl $TargetDir
+if (Test-Path $TargetDir) {
+    Write-Info "Removing existing installation at $TargetDir..."
+    Remove-Item $TargetDir -Recurse -Force
+}
+
+Write-Info "Cloning from: $MarketplaceGitUrl"
+git clone --depth 1 $MarketplaceGitUrl $TargetDir 2>&1
 if ($LASTEXITCODE -ne 0) {
-    Write-Host "Error: Failed to clone repository" -ForegroundColor Red
+    Write-Err "Failed to clone repository"
     exit 1
 }
 
-# Update known_marketplaces.json
+# Verify marketplace.json exists
+$MarketplaceJson = Join-Path $TargetDir ".claude-plugin\marketplace.json"
+if (-not (Test-Path $MarketplaceJson)) {
+    Write-Err "marketplace.json not found in cloned repository"
+    exit 1
+}
+
+# =============================================================================
+# Register in known_marketplaces.json
+# =============================================================================
+
 Write-Info "Registering marketplace..."
+
 if (-not (Test-Path $ClaudePluginsDir)) {
     New-Item -ItemType Directory -Force -Path $ClaudePluginsDir | Out-Null
 }
@@ -98,29 +88,47 @@ if (-not (Test-Path $KnownMarketplacesFile)) {
     [System.IO.File]::WriteAllText($KnownMarketplacesFile, '{}', (New-Object System.Text.UTF8Encoding($false)))
 }
 
-$json = Get-Content $KnownMarketplacesFile -Raw | ConvertFrom-Json
+$jsonContent = Get-Content $KnownMarketplacesFile -Raw
+$json = $jsonContent | ConvertFrom-Json
+
 $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.000Z")
 
-$json | Add-Member -MemberType NoteProperty -Name $MarketplaceName -Value @{
-    source = @{ source = "github"; repo = "ttttstc/vibeflow" }
+# Add marketplace entry
+$marketplaceEntry = @{
+    source = @{
+        source = "github"
+        repo = $RepoName
+    }
     installLocation = $TargetDir
     lastUpdated = $timestamp
-} -Force
+}
+$json | Add-Member -MemberType NoteProperty -Name $MarketplaceName -Value $marketplaceEntry -Force
 
+# Write back with formatting
 $compact = $json | ConvertTo-Json -Depth 10 -Compress
-$formatted = Format-Json $compact
-[System.IO.File]::WriteAllText($KnownMarketplacesFile, $formatted, (New-Object System.Text.UTF8Encoding($false)))
+[System.IO.File]::WriteAllText($KnownMarketplacesFile, $compact, (New-Object System.Text.UTF8Encoding($false)))
+
+# =============================================================================
+# Verify
+# =============================================================================
+
+$verifyContent = Get-Content $KnownMarketplacesFile -Raw | ConvertFrom-Json
+if (-not $verifyContent.PSObject.Properties.Name.Contains($MarketplaceName)) {
+    Write-Err "Marketplace registration failed"
+    exit 1
+}
 
 # =============================================================================
 # Success
 # =============================================================================
 
 Write-Host ""
-Write-Host "✓ Marketplace installed successfully!" -ForegroundColor Green
+Write-Success "VibeFlow marketplace installed successfully!"
 Write-Host ""
-Write-Host "  Name: $MarketplaceName"
-Write-Host "  Path: $TargetDir"
+Write-Host "  Marketplace key: $MarketplaceName"
+Write-Host "  Install path:    $TargetDir"
+Write-Host "  Git repo:       $MarketplaceGitUrl"
 Write-Host ""
-Write-Host "To install plugins, use Claude Code:" -ForegroundColor White -BackgroundColor DarkBlue
-Write-Host "  /plugin install vibeflow@$MarketplaceName"
+Write-Host "To activate the plugin, run in Claude Code:"
+Write-Host "  /plugin install vibeflow@vibeflow"
 Write-Host ""

--- a/claude-code/install.sh
+++ b/claude-code/install.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 
 MARKETPLACE_GIT_URL="https://github.com/ttttstc/vibeflow.git"
 MARKETPLACE_NAME="vibeflow"
+REPO_NAME="ttttstc/vibeflow"
 
 # =============================================================================
 # Paths
@@ -35,47 +36,57 @@ if [[ -t 1 ]]; then
   GREEN='\033[0;32m'
   BLUE='\033[0;34m'
   YELLOW='\033[0;33m'
+  RED='\033[0;31m'
   BOLD='\033[1m'
   RESET='\033[0m'
 else
   GREEN=''
   BLUE=''
   YELLOW=''
+  RED=''
   BOLD=''
   RESET=''
 fi
 
-info()    { echo -e "${BLUE}ℹ${RESET} $*"; }
-warn()    { echo -e "${YELLOW}⚠${RESET} $*"; }
-success() { echo -e "${GREEN}✓${RESET} $*"; }
+info()    { echo -e "${BLUE}[INFO]${RESET} $*"; }
+success() { echo -e "${GREEN}[SUCCESS]${RESET} $*"; }
+error()   { echo -e "${RED}[ERROR]${RESET} $*" >&2; }
 
 # =============================================================================
 # Pre-flight Check
 # =============================================================================
 
 if ! command -v git &>/dev/null; then
-  echo "Error: git is not installed" >&2
+  error "git is not installed"
+  exit 1
+fi
+
+info "Installing vibeflow marketplace..."
+
+# =============================================================================
+# Clone or Update
+# =============================================================================
+
+mkdir -p "$MARKETPLACES_DIR"
+
+if [[ -d "$TARGET_DIR" ]]; then
+  info "Removing existing installation at $TARGET_DIR..."
+  rm -rf "$TARGET_DIR"
+fi
+
+info "Cloning from: $MARKETPLACE_GIT_URL"
+git clone --depth 1 "$MARKETPLACE_GIT_URL" "$TARGET_DIR"
+
+# Verify marketplace.json exists
+if [[ ! -f "$TARGET_DIR/.claude-plugin/marketplace.json" ]]; then
+  error "marketplace.json not found in cloned repository"
   exit 1
 fi
 
 # =============================================================================
-# Install
+# Register in known_marketplaces.json
 # =============================================================================
 
-info "Installing marketplace: $MARKETPLACE_NAME"
-
-# Remove existing if present
-if [[ -d "$TARGET_DIR" ]]; then
-  info "Removing existing installation..."
-  rm -rf "$TARGET_DIR"
-fi
-
-# Clone repository
-info "Cloning from: $MARKETPLACE_GIT_URL"
-mkdir -p "$MARKETPLACES_DIR"
-git clone --depth 1 "$MARKETPLACE_GIT_URL" "$TARGET_DIR"
-
-# Update known_marketplaces.json
 info "Registering marketplace..."
 mkdir -p "$CLAUDE_PLUGINS_DIR"
 
@@ -83,10 +94,7 @@ if [[ ! -f "$KNOWN_MARKETPLACES_FILE" ]]; then
   echo '{}' > "$KNOWN_MARKETPLACES_FILE"
 fi
 
-# Update known_marketplaces.json using jq
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
-REPO_NAME="${MARKETPLACE_GIT_URL#https://github.com/}"
-REPO_NAME="${REPO_NAME%.git}"
 
 if command -v jq &>/dev/null; then
   jq --arg name "$MARKETPLACE_NAME" \
@@ -100,7 +108,18 @@ if command -v jq &>/dev/null; then
      }' "$KNOWN_MARKETPLACES_FILE" > "${KNOWN_MARKETPLACES_FILE}.tmp" && \
   mv "${KNOWN_MARKETPLACES_FILE}.tmp" "$KNOWN_MARKETPLACES_FILE"
 else
-  warn "jq not found, skipping known_marketplaces.json update"
+  error "jq is not installed - cannot update known_marketplaces.json"
+  error "Install jq: brew install jq (macOS) or apt install jq (Linux)"
+  exit 1
+fi
+
+# =============================================================================
+# Verify
+# =============================================================================
+
+if ! jq -e ".$MARKETPLACE_NAME" "$KNOWN_MARKETPLACES_FILE" &>/dev/null; then
+  error "Marketplace registration failed"
+  exit 1
 fi
 
 # =============================================================================
@@ -108,11 +127,12 @@ fi
 # =============================================================================
 
 echo ""
-echo -e "${BOLD}${GREEN}✓ Marketplace installed successfully!${RESET}"
+success "VibeFlow marketplace installed successfully!"
 echo ""
-echo "  Name: $MARKETPLACE_NAME"
-echo "  Path: $TARGET_DIR"
+echo "  Marketplace key: $MARKETPLACE_NAME"
+echo "  Install path:    $TARGET_DIR"
+echo "  Git repo:       $MARKETPLACE_GIT_URL"
 echo ""
-echo -e "${BOLD}To install plugins, use Claude Code:${RESET}"
-echo "  /plugin install vibeflow@$MARKETPLACE_NAME"
+echo "To activate the plugin, run in Claude Code:"
+echo "  /plugin install vibeflow@vibeflow"
 echo ""


### PR DESCRIPTION
## Summary

Post-PR #16 fixes: P1 review blockers, marketplace installer improvements, and README rewrite.

### P1 Review Blockers Fixed
- Remove `ucd` phase from `detect_phase()` — UCD is now inlined into Design phase
- Gate Design phase on `.vibeflow/plan-eng-review.md` and `.vibeflow/plan-design-review.md` existence
- Sync tests with new architecture (remove `test_ucd_required_missing`, add eng/design review gate tests)
- Update `vibeflow-router` SKILL.md phase list

### Marketplace Installer Fixes
- `install.ps1`: Add repo verification, better error messages, validate marketplace.json after clone, verify registration succeeded
- `install.sh`: Fail fast if jq missing (can't update known_marketplaces.json without it)
- Both: explicit SUCCESS/INFO/ERROR output, clearer instructions

### Documentation Sync
- `VIBEFLOW-DESIGN.md`: v1.3, update to 16-phase architecture, add new skills (office-hours, plan-eng-review, plan-design-review, brainstorming, safety guards), reorganize skill catalog into 5 layers
- `validation/sample-priority-api`: Add `plan.md`, `plan-value-review.md`, `plan-eng-review.md`, `plan-design-review.md` — phase detection now correctly returns `done`
- `README.md` + `README_EN.md`: Rewrite in longtaskforagent format with language switching, 3 installation methods, 16-phase ASCII diagram, 23 skills table

## Test plan

- [x] `pytest tests/test_detect_phase.py -v` — 27 passed
- [x] `python scripts/get-vibeflow-phase.py --project-root validation/sample-priority-api --verbose` → `done`
- [x] Marketplace clone succeeds: `git clone --depth 1 https://github.com/ttttstc/vibeflow.git`
- [x] All 27 skills have valid SKILL.md with name + description frontmatter
- [x] marketplace.json and plugin.json are valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)