### PR TITLE
fix: install.sh ZIP fallback + all URLs point to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 在 Claude Code 对话框中运行：
 
 ```
-/sh curl -fsSL https://raw.githubusercontent.com/ttttstc/vibeflow/refs/heads/feat/plan-value-review/claude-code/install.sh | bash
+/sh curl -fsSL https://raw.githubusercontent.com/ttttstc/vibeflow/main/claude-code/install.sh | bash
 ```
 
 安装完成后激活：
@@ -41,10 +41,10 @@
    方式A - git clone：
    git clone --depth 1 https://github.com/ttttstc/vibeflow.git ~/.claude/plugins/marketplaces/vibeflow
    方式B - 如果 git 不可用，用 curl 下载 ZIP：
-   curl -fsSL https://github.com/ttttstc/vibeflow/archive/refs/heads/feat/plan-value-review.zip -o /tmp/vibeflow.zip
+   curl -fsSL https://github.com/ttttstc/vibeflow/archive/refs/heads/main.zip -o /tmp/vibeflow.zip
    unzip /tmp/vibeflow.zip -d /tmp/
    rm -rf ~/.claude/plugins/marketplaces/vibeflow
-   mv /tmp/vibeflow-feat-plan-value-review ~/.claude/plugins/marketplaces/vibeflow
+   mv /tmp/vibeflow-main ~/.claude/plugins/marketplaces/vibeflow
 
 2. 在 ~/.claude/plugins/known_marketplaces.json 注册（如果文件不存在则创建）：
    使用 jq 或 python3 更新 JSON，添加：
@@ -62,7 +62,7 @@
 双击即用，自动完成下载 + 安装 + 启动 Claude Code + 加载插件：
 
 ```powershell
-irm https://raw.githubusercontent.com/ttttstc/vibeflow/refs/heads/feat/plan-value-review/claude-code/vibeflow-launcher.ps1 | iex
+irm https://raw.githubusercontent.com/ttttstc/vibeflow/main/claude-code/vibeflow-launcher.ps1 | iex
 ```
 
 ---

--- a/claude-code/INSTALL-PROMPT.md
+++ b/claude-code/INSTALL-PROMPT.md
@@ -5,7 +5,7 @@
 在 Claude Code 对话框中运行：
 
 ```
-/sh curl -fsSL https://raw.githubusercontent.com/ttttstc/vibeflow/refs/heads/feat/plan-value-review/claude-code/install.sh | bash
+/sh curl -fsSL https://raw.githubusercontent.com/ttttstc/vibeflow/main/claude-code/install.sh | bash
 ```
 
 安装完成后激活：
@@ -31,10 +31,10 @@
    git clone --depth 1 https://github.com/ttttstc/vibeflow.git ~/.claude/plugins/marketplaces/vibeflow
 
    方式B - 如果 git 不可用，用 curl 下载 ZIP：
-   curl -fsSL https://github.com/ttttstc/vibeflow/archive/refs/heads/feat/plan-value-review.zip -o /tmp/vibeflow.zip
+   curl -fsSL https://github.com/ttttstc/vibeflow/archive/refs/heads/main.zip -o /tmp/vibeflow.zip
    unzip /tmp/vibeflow.zip -d /tmp/
    rm -rf ~/.claude/plugins/marketplaces/vibeflow
-   mv /tmp/vibeflow-feat-plan-value-review ~/.claude/plugins/marketplaces/vibeflow
+   mv /tmp/vibeflow-main ~/.claude/plugins/marketplaces/vibeflow
 
 2. 确保目录是 ~/.claude/plugins/marketplaces/vibeflow/
 
@@ -89,5 +89,5 @@
 如果遇到问题，运行诊断脚本：
 
 ```
-/sh curl -fsSL https://raw.githubusercontent.com/ttttstc/vibeflow/refs/heads/feat/plan-value-review/claude-code/debug-install.ps1 | iex
+/sh curl -fsSL https://raw.githubusercontent.com/ttttstc/vibeflow/main/claude-code/debug-install.ps1 | iex
 ```

--- a/claude-code/install-all-in-one.ps1
+++ b/claude-code/install-all-in-one.ps1
@@ -4,7 +4,7 @@
 #
 # 使用方法：在 Claude Code 中运行（只需要这一条命令）：
 #
-#   /sh irm https://raw.githubusercontent.com/ttttstc/vibeflow/refs/heads/feat/plan-value-review/claude-code/install-all-in-one.ps1 | iex
+#   /sh irm https://raw.githubusercontent.com/ttttstc/vibeflow/main/claude-code/install-all-in-one.ps1 | iex
 #
 # 安装程序会自动完成：
 #   1. 下载 vibeflow 文件到 ~/.claude/plugins/marketplaces/vibeflow/
@@ -23,8 +23,8 @@ param(
 $ErrorActionPreference = "Stop"
 
 $MarketplaceName = "vibeflow"
-$Branch = "feat/plan-value-review"
-$DownloadUrl = "https://github.com/ttttstc/vibeflow/archive/refs/heads/$Branch.zip"
+$Branch = "main"
+$DownloadUrl = "https://github.com/ttttstc/vibeflow/archive/refs/heads/main.zip"
 
 $ClaudePluginsDir = Join-Path $env:USERPROFILE ".claude\plugins"
 $MarketplacesDir = Join-Path $ClaudePluginsDir "marketplaces"

--- a/claude-code/install-simple.ps1
+++ b/claude-code/install-simple.ps1
@@ -3,10 +3,10 @@
 # =============================================================================
 #
 # Usage:
-#   irm https://raw.githubusercontent.com/ttttstc/vibeflow/refs/heads/feat/plan-value-review/claude-code/install-simple.ps1 | iex
+#   irm https://raw.githubusercontent.com/ttttstc/vibeflow/main/claude-code/install-simple.ps1 | iex
 #
 # Or download and run manually:
-#   Invoke-WebRequest -Uri "https://raw.githubusercontent.com/ttttstc/vibeflow/refs/heads/feat/plan-value-review/claude-code/install-simple.ps1" -OutFile install-simple.ps1
+#   Invoke-WebRequest -Uri "https://raw.githubusercontent.com/ttttstc/vibeflow/main/claude-code/install-simple.ps1" -OutFile install-simple.ps1
 #   .\install-simple.ps1
 #
 
@@ -14,8 +14,8 @@ $ErrorActionPreference = "Stop"
 
 $MarketplaceName = "vibeflow"
 $RepoUrl = "https://github.com/ttttstc/vibeflow"
-$Branch = "refs/heads/feat/plan-value-review"
-$DownloadUrl = "https://github.com/ttttstc/vibeflow/archive/refs/heads/feat/plan-value-review.zip"
+$Branch = "refs/heads/main"
+$DownloadUrl = "https://github.com/ttttstc/vibeflow/archive/refs/heads/main.zip"
 
 $ClaudePluginsDir = Join-Path $env:USERPROFILE ".claude\plugins"
 $MarketplacesDir = Join-Path $ClaudePluginsDir "marketplaces"
@@ -45,13 +45,13 @@ $TempZip = Join-Path $env:TEMP "vibeflow-download.zip"
 $TempExtract = Join-Path $env:TEMP "vibeflow-extract"
 
 try {
-    Invoke-WebRequest -Uri "https://github.com/ttttstc/vibeflow/archive/refs/heads/feat/plan-value-review.zip" -OutFile $TempZip -UserAgent "vibeflow-installer/1.0"
+    Invoke-WebRequest -Uri "https://github.com/ttttstc/vibeflow/archive/refs/heads/main.zip" -OutFile $TempZip -UserAgent "vibeflow-installer/1.0"
     Write-Host "  Downloaded ($((Get-Item $TempZip).Length / 1MB) MB)" -ForegroundColor Green
 
     # Extract
     Write-Host "  Extracting..." -ForegroundColor Green
     Expand-Archive -Path $TempZip -DestinationPath $TempExtract -Force
-    $ExtractedRepo = Join-Path $TempExtract "vibeflow-feat-plan-value-review"
+    $ExtractedRepo = Join-Path $TempExtract "vibeflow-main"
 
     # Move to final location
     Move-Item -Path $ExtractedRepo -Destination $TargetDir -Force

--- a/claude-code/install.sh
+++ b/claude-code/install.sh
@@ -5,11 +5,7 @@
 #
 # 使用方法：复制以下命令，粘贴到 Claude Code 对话框运行：
 #
-#   /sh curl -fsSL https://raw.githubusercontent.com/ttttstc/vibeflow/refs/heads/feat/plan-value-review/claude-code/install.sh | bash
-#
-# 或者一行：
-#
-#   /sh bash -c "$(curl -fsSL https://raw.githubusercontent.com/ttttstc/vibeflow/refs/heads/feat/plan-value-review/claude-code/install.sh)"
+#   /sh curl -fsSL https://raw.githubusercontent.com/ttttstc/vibeflow/main/claude-code/install.sh | bash
 #
 # 安装后运行：
 #   /plugin install vibeflow@vibeflow
@@ -19,10 +15,7 @@
 set -euo pipefail
 
 MARKETPLACE_NAME="vibeflow"
-BRANCH="feat/plan-value-review"
-DOWNLOAD_URL="https://github.com/ttttstc/vibeflow/archive/refs/heads/${BRANCH}.zip"
-GITHUB_RAW="https://raw.githubusercontent.com/ttttstc/vibeflow/refs/heads/${BRANCH}"
-
+BRANCH="main"
 MARKETPLACE_GIT_URL="https://github.com/ttttstc/vibeflow.git"
 REPO_NAME="ttttstc/vibeflow"
 
@@ -41,12 +34,6 @@ info()    { echo -e "${CYAN}[INFO]${RESET} $*"; }
 success() { echo -e "${GREEN}[OK]${RESET} $*"; }
 error()   { echo -e "${RED}[ERROR]${RESET} $*" >&2; }
 
-# Check git
-if ! command -v git &>/dev/null; then
-  error "git is required but not installed"
-  exit 1
-fi
-
 info "开始安装 VibeFlow..."
 
 # 1. Create directories
@@ -59,14 +46,56 @@ if [[ -d "$TARGET_DIR" ]]; then
   rm -rf "$TARGET_DIR"
 fi
 
-# 3. Clone
+# 3. Download - try git first, fall back to ZIP
 info "下载中..."
-git clone --depth 1 "$MARKETPLACE_GIT_URL" "$TARGET_DIR" 2>&1
-if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
-  error "下载失败"
-  exit 1
+
+download_ok=false
+if command -v git &>/dev/null; then
+  if git clone --depth 1 "$MARKETPLACE_GIT_URL" "$TARGET_DIR" 2>&1; then
+    download_ok=true
+    success "下载完成 (git)"
+  fi
 fi
-success "下载完成"
+
+if [[ "$download_ok" != "true" ]]; then
+  info "git 不可用，尝试 ZIP 下载..."
+  TEMP_ZIP="/tmp/vibeflow-download.zip"
+  TEMP_EXTRACT="/tmp/vibeflow-extract"
+
+  if command -v curl &>/dev/null; then
+    curl -fsSL "https://github.com/ttttstc/vibeflow/archive/refs/heads/${BRANCH}.zip" -o "$TEMP_ZIP" 2>&1
+  elif command -v wget &>/dev/null; then
+    wget -q "https://github.com/ttttstc/vibeflow/archive/refs/heads/${BRANCH}.zip" -O "$TEMP_ZIP" 2>&1
+  else
+    error "curl 和 wget 都不可用，无法下载"
+    exit 1
+  fi
+
+  if [[ ! -f "$TEMP_ZIP" ]]; then
+    error "下载失败"
+    exit 1
+  fi
+
+  rm -rf "$TEMP_EXTRACT"
+  mkdir -p "$TEMP_EXTRACT"
+  if command -v unzip &>/dev/null; then
+    unzip -q "$TEMP_ZIP" -d "$TEMP_EXTRACT"
+  else
+    error "unzip 不可用"
+    exit 1
+  fi
+
+  # Find extracted directory (handles any branch name)
+  EXTRACTED_DIR=$(find "$TEMP_EXTRACT" -maxdepth 1 -type d -name "vibeflow-*" | head -1)
+  if [[ -z "$EXTRACTED_DIR" ]]; then
+    error "解压失败，无法找到 vibeflow 目录"
+    exit 1
+  fi
+
+  mv "$EXTRACTED_DIR" "$TARGET_DIR"
+  rm -rf "$TEMP_ZIP" "$TEMP_EXTRACT"
+  success "下载完成 (ZIP)"
+fi
 
 # 4. Verify
 MARKETPLACE_JSON="${TARGET_DIR}/.claude-plugin/marketplace.json"

--- a/claude-code/vibeflow-launcher.ps1
+++ b/claude-code/vibeflow-launcher.ps1
@@ -6,7 +6,7 @@
 #   .\vibeflow-launcher.ps1
 #
 # 或者一行命令（推荐）：
-#   irm https://raw.githubusercontent.com/ttttstc/vibeflow/refs/heads/feat/plan-value-review/claude-code/vibeflow-launcher.ps1 | iex
+#   irm https://raw.githubusercontent.com/ttttstc/vibeflow/main/claude-code/vibeflow-launcher.ps1 | iex
 #
 # 此脚本会：
 #   1. 检查并安装 vibeflow（如需要）
@@ -20,9 +20,9 @@
 $ErrorActionPreference = "Stop"
 
 $MarketplaceName = "vibeflow"
-$Branch = "feat/plan-value-review"
-$DownloadUrl = "https://github.com/ttttstc/vibeflow/archive/refs/heads/$Branch.zip"
-$RawBase = "https://raw.githubusercontent.com/ttttstc/vibeflow/refs/heads/$Branch"
+$Branch = "main"
+$DownloadUrl = "https://github.com/ttttstc/vibeflow/archive/refs/heads/main.zip"
+$RawBase = "https://raw.githubusercontent.com/ttttstc/vibeflow/refs/heads/main"
 
 $ClaudePluginsDir = Join-Path $env:USERPROFILE ".claude\plugins"
 $MarketplacesDir = Join-Path $ClaudePluginsDir "marketplaces"
@@ -153,7 +153,7 @@ if (Test-VibeflowInstalled) {
         Write-Host ""
         Write-Host "安装失败，请检查网络后重试" -ForegroundColor Red
         Write-Host "或者手动下载安装："
-        Write-Host "  irm https://raw.githubusercontent.com/ttttstc/vibeflow/refs/heads/feat/plan-value-review/claude-code/install-simple.ps1 | iex" -ForegroundColor Gray
+        Write-Host "  irm https://raw.githubusercontent.com/ttttstc/vibeflow/main/claude-code/install-simple.ps1 | iex" -ForegroundColor Gray
         exit 1
     }
 }


### PR DESCRIPTION
## Summary

修复 Issue #22 和 #23：

**Issue #22: install.sh 需要 ZIP fallback**
- install.sh 现在支持 ZIP 下载 fallback
- 优先尝试 git clone，git 不可用时自动切换到 curl/wget + unzip
- 不再强制要求 git

**Issue #23: 所有安装入口应指向 main 分支**
- 所有 URL 从 `feat/plan-value-review` 改为 `main`
- 影响文件：README.md、INSTALL-PROMPT.md、install.sh、install-simple.ps1、install-all-in-one.ps1、vibeflow-launcher.ps1

## Changed

| 文件 | 变更 |
|------|------|
| `install.sh` | 添加 ZIP fallback，URL → main |
| `install-simple.ps1` | URL → main，解压目录名 → vibeflow-main |
| `install-all-in-one.ps1` | URL → main |
| `vibeflow-launcher.ps1` | URL → main |
| `INSTALL-PROMPT.md` | 全部 URL → main |
| `README.md` | 全部 URL → main |

🤖 Generated with [Claude Code](https://claude.com/claude-code)