### PR TITLE
Refresh README homepage copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,29 @@ VibeFlow 给它一套可恢复、可追踪、可测试的交付流程：**文件
 
 > 你可以把它理解成：给 AI 配上路线图、安全带和刹车系统。
 
+## 一眼看懂流程
+
+```mermaid
+flowchart LR
+    A["开始"] --> B{"选择模式"}
+    B -->|复杂任务| C["Full Mode"]
+    B -->|小改动| D["Quick Mode"]
+    C --> C1["Think"]
+    C1 --> C2["Plan"]
+    C2 --> C3["Requirements"]
+    C3 --> C4["Design"]
+    C4 --> E["Build"]
+    D --> D1["Quick"]
+    D1 --> E["Build"]
+    E --> F["Review"]
+    F --> G["Test"]
+    G --> H["Ship?"]
+    H --> I["Reflect?"]
+```
+
+想法很多、风险不明、边界不清的时候走 Full。  
+改动很小、很好验证、回滚也简单的时候走 Quick。
+
 ## 为什么会有它
 
 没有流程的 AI 编程，常见结局通常长这样：

--- a/README_EN.md
+++ b/README_EN.md
@@ -13,6 +13,29 @@ VibeFlow gives it a delivery system with **file-based state, deterministic routi
 
 > Think of it as guardrails, a map, and a memory system for AI-driven software delivery.
 
+## Flow At A Glance
+
+```mermaid
+flowchart LR
+    A["Start"] --> B{"Pick a mode"}
+    B -->|Complex work| C["Full Mode"]
+    B -->|Small change| D["Quick Mode"]
+    C --> C1["Think"]
+    C1 --> C2["Plan"]
+    C2 --> C3["Requirements"]
+    C3 --> C4["Design"]
+    C4 --> E["Build"]
+    D --> D1["Quick"]
+    D1 --> E["Build"]
+    E --> F["Review"]
+    F --> G["Test"]
+    G --> H["Ship?"]
+    H --> I["Reflect?"]
+```
+
+Use Full Mode when the work is fuzzy, risky, or broad.  
+Use Quick Mode when the change is small, easy to verify, and easy to roll back.
+
 ## Why It Exists
 
 Without a real workflow, AI coding usually looks like this:


### PR DESCRIPTION
## Summary
- rewrite the Chinese and English README homepages to match the refactored VibeFlow capabilities
- shorten installation guidance and push detailed install paths into linked scripts and docs
- clarify Full Mode vs Quick Mode, the v2 state/artifact layout, and the primary getting-started path
- tighten the tone so the homepage reads more like a product landing page than an internal handbook

## Testing
- not run (documentation-only change)
