### PR TITLE
feat(vibeflow): support project rules packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ VibeFlow 不只有一条固定强度的流程。
 | `.vibeflow/state.json` | 当前工作流真相：模式、阶段、工作包、checkpoint |
 | `.vibeflow/runtime.json` | 运行态覆盖层：当前动作、友好提示、最近事件、heartbeat |
 | `.vibeflow/codebase-map.json` | 项目级代码结构地图，给现有项目改动复用 |
+| `rules/` | 项目自定义约束目录；存在时会作为 spec 补充输入，并优先于根目录 `CLAUDE.md` / `AGENT.md` |
 | `feature-list.json` | Build 阶段的功能清单和执行真相 |
 | `docs/changes/<change-id>/context.md` | 这次工作的起点、边界和目标 |
 | `docs/changes/<change-id>/proposal.md` | 这次方案的范围和价值判断 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -300,6 +300,7 @@ Ship -> Reflect
 | `.vibeflow/state.json` | Source of truth for phase, mode, active change, and checkpoints |
 | `.vibeflow/runtime.json` | Runtime overlay for current action, friendly guidance, recent events, and heartbeat |
 | `.vibeflow/codebase-map.json` | Reusable project-level code structure map |
+| `rules/` | Optional project custom constraints; when present they are treated as spec-side input and take precedence over root `CLAUDE.md` / `AGENT.md` guidance |
 | `feature-list.json` | Build-time source of truth for features and execution state |
 | `docs/changes/<change-id>/context.md` | Starting context, scope, and constraints |
 | `docs/changes/<change-id>/proposal.md` | Scope and value framing for this change |

--- a/USAGE.md
+++ b/USAGE.md
@@ -10,6 +10,7 @@
 
 A target project is expected to accumulate these artifacts over time:
 
+- `rules/` for optional project-level custom constraints that should override root agent guidance files when they conflict
 - `.vibeflow/state.json`
 - `.vibeflow/workflow.yaml`
 - `.vibeflow/work-config.json`

--- a/scripts/get-vibeflow-paths.py
+++ b/scripts/get-vibeflow-paths.py
@@ -31,6 +31,7 @@ def main():
         "session_log": str(contract["session_log"]),
         "build_guide": str(contract["build_guide"]),
         "services_guide": str(contract["services_guide"]),
+        "rules_dir": str(contract["rules_dir"]),
         "change_root": str(contract["change_root"]),
         "packets_dir": str(contract["packets_dir"]),
         "packet_results_dir": str(contract["packet_results_dir"]),

--- a/scripts/vibeflow_automation.py
+++ b/scripts/vibeflow_automation.py
@@ -36,6 +36,7 @@ from vibeflow_packets import (  # noqa: E402
     write_feature_result,
 )
 from vibeflow_overview import refresh_current_state  # noqa: E402
+from vibeflow_rules import load_project_rules  # noqa: E402
 
 
 MANUAL_ONLY_PHASES = {
@@ -624,9 +625,30 @@ def review_spec_compliance(project_root: Path, state: dict, payload: dict) -> di
     notes: list[str] = []
     contract = path_contract(project_root, state)
     features = active_features(payload)
+    rules_context = load_project_rules(project_root)
+    expected_rule_ids = [
+        str(rule.get("id") or "").strip()
+        for rule in rules_context.get("files") or []
+        if str(rule.get("id") or "").strip()
+    ]
+    expected_rule_paths = [
+        str(rule.get("path") or "").strip()
+        for rule in rules_context.get("files") or []
+        if str(rule.get("path") or "").strip()
+    ]
 
     if not features:
         issues.append("No active features found in feature-list.json.")
+
+    if rules_context.get("enabled"):
+        notes.append(
+            f"- Project custom rules: {len(expected_rule_ids)} file(s) loaded from {rules_context.get('rules_dir', 'rules/')}"
+        )
+        guidance_files = normalize_command_list(rules_context.get("agent_guidance_files"))
+        if guidance_files:
+            notes.append(
+                "- Conflict precedence: rules/ overrides " + ", ".join(guidance_files)
+            )
 
     for feature in features:
         feature_id = feature.get("id")
@@ -642,6 +664,33 @@ def review_spec_compliance(project_root: Path, state: dict, payload: dict) -> di
                 f"Feature #{feature_id} ({title}): implementation packet is incomplete: "
                 + "; ".join(packet_issues)
             )
+
+        if rules_context.get("enabled"):
+            custom_rules = packet.get("custom_rules") if isinstance(packet.get("custom_rules"), dict) else {}
+            source_refs = packet.get("source_refs") if isinstance(packet.get("source_refs"), dict) else {}
+            packet_rule_ids = [
+                str(rule.get("id") or "").strip()
+                for rule in custom_rules.get("files") or []
+                if isinstance(rule, dict) and str(rule.get("id") or "").strip()
+            ]
+            packet_rule_paths = normalize_command_list(source_refs.get("rules"))
+
+            if not custom_rules.get("enabled"):
+                issues.append(
+                    f"Feature #{feature_id} ({title}): custom rules exist in rules/ but were not injected into the implementation packet."
+                )
+            elif packet_rule_ids != expected_rule_ids:
+                issues.append(
+                    f"Feature #{feature_id} ({title}): implementation packet custom rules differ from the current project rules."
+                )
+            elif packet_rule_paths != expected_rule_paths:
+                issues.append(
+                    f"Feature #{feature_id} ({title}): source_refs.rules does not match the current project rules."
+                )
+            elif not str(custom_rules.get("precedence_note") or "").strip():
+                issues.append(
+                    f"Feature #{feature_id} ({title}): custom rules precedence note is missing."
+                )
 
         result_path = contract["packet_results_dir"] / f"feature-{feature_id}.json"
         if not result_path.exists():
@@ -677,7 +726,7 @@ def review_spec_compliance(project_root: Path, state: dict, payload: dict) -> di
         lines.extend(["", "Issues:", "- None."])
 
     return {
-        "label": "Implementation Delivery Consistency",
+        "label": "Implementation Delivery & Rule Consistency" if rules_context.get("enabled") else "Implementation Delivery Consistency",
         "ok": not issues,
         "exit_code": 0 if not issues else 1,
         "body": "\n".join(lines).strip(),

--- a/scripts/vibeflow_packets.py
+++ b/scripts/vibeflow_packets.py
@@ -10,11 +10,12 @@ from vibeflow_paths import (
     build_packet_result_path,
     path_contract,
 )
+from vibeflow_rules import load_project_rules
 
 
 PACKET_VERSION = 1
 SUMMARY_CHAR_LIMIT = 480
-SOURCE_REF_KEYS = ("think", "plan", "requirements", "design", "tasks", "build_guide", "services_guide")
+SOURCE_REF_KEYS = ("think", "plan", "requirements", "design", "tasks", "build_guide", "services_guide", "rules")
 
 
 def normalize_string_list(value) -> list[str]:
@@ -48,7 +49,7 @@ def _task_anchor(feature_id: int | str) -> str:
     return f"feature-{feature_id}"
 
 
-def _default_source_refs(contract: dict, feature_id: int | str) -> dict[str, list[str]]:
+def _default_source_refs(contract: dict, feature_id: int | str, rules_refs: list[str] | None = None) -> dict[str, list[str]]:
     default_refs = {
         "think": [str(contract["artifacts"]["think"])],
         "plan": [str(contract["artifacts"]["plan"])],
@@ -58,11 +59,19 @@ def _default_source_refs(contract: dict, feature_id: int | str) -> dict[str, lis
         "build_guide": [str(contract["build_guide"])],
         "services_guide": [str(contract["services_guide"])],
     }
+    if rules_refs:
+        default_refs["rules"] = list(rules_refs)
     return default_refs
 
 
-def _normalize_source_refs(raw_source_refs, contract: dict, feature_id: int | str) -> dict[str, list[str]]:
-    normalized = _default_source_refs(contract, feature_id)
+def _normalize_source_refs(
+    raw_source_refs,
+    contract: dict,
+    feature_id: int | str,
+    *,
+    rules_refs: list[str] | None = None,
+) -> dict[str, list[str]]:
+    normalized = _default_source_refs(contract, feature_id, rules_refs=rules_refs)
     if not isinstance(raw_source_refs, dict):
         return normalized
 
@@ -94,14 +103,60 @@ def summarize_markdown(path: Path, *, limit: int = SUMMARY_CHAR_LIMIT) -> str:
     return summary[: limit - 3].rstrip() + "..."
 
 
-def ensure_feature_contract(feature: dict, project_root: Path, state: dict) -> dict:
+def _normalize_custom_rules(rules_context: dict) -> dict:
+    files: list[dict] = []
+    for rule in rules_context.get("files") or []:
+        if not isinstance(rule, dict):
+            continue
+        files.append(
+            {
+                "id": str(rule.get("id") or "").strip(),
+                "title": str(rule.get("title") or "").strip(),
+                "path": str(rule.get("path") or "").strip(),
+                "format": str(rule.get("format") or "").strip(),
+                "summary": str(rule.get("summary") or "").strip(),
+                "content": str(rule.get("content") or "").strip(),
+            }
+        )
+    return {
+        "enabled": bool(rules_context.get("enabled") and files),
+        "precedence_note": str(rules_context.get("precedence_note") or "").strip(),
+        "agent_guidance_files": normalize_string_list(rules_context.get("agent_guidance_files")),
+        "files": files,
+    }
+
+
+def _rules_summary(custom_rules: dict) -> str:
+    if not custom_rules.get("enabled"):
+        return ""
+    lines: list[str] = []
+    for rule in custom_rules.get("files") or []:
+        if not isinstance(rule, dict):
+            continue
+        title = str(rule.get("title") or rule.get("id") or "").strip()
+        summary = str(rule.get("summary") or "").strip()
+        if title and summary:
+            lines.append(f"{title}: {summary}")
+        elif title:
+            lines.append(title)
+        if len(" ".join(lines)) >= SUMMARY_CHAR_LIMIT:
+            break
+    summary = " ".join(lines).strip()
+    if len(summary) <= SUMMARY_CHAR_LIMIT:
+        return summary
+    return summary[: SUMMARY_CHAR_LIMIT - 3].rstrip() + "..."
+
+
+def ensure_feature_contract(feature: dict, project_root: Path, state: dict, *, rules_context: dict | None = None) -> dict:
     contract = path_contract(project_root, state)
+    loaded_rules = rules_context or load_project_rules(project_root)
     normalized = deepcopy(feature)
 
     feature_id = normalized.get("id")
     title = str(normalized.get("title") or f"Feature {feature_id}").strip()
     description = str(normalized.get("description") or title).strip()
     commands, workdir, timeout = feature_execution_config(normalized)
+    rules_refs = [str(rule.get("path") or "").strip() for rule in loaded_rules.get("files") or [] if str(rule.get("path") or "").strip()]
 
     normalized["title"] = title
     normalized["description"] = description
@@ -123,7 +178,13 @@ def ensure_feature_contract(feature: dict, project_root: Path, state: dict) -> d
 
     normalized["risk_notes"] = normalize_string_list(normalized.get("risk_notes"))
     normalized["required_configs"] = normalize_string_list(normalized.get("required_configs"))
-    normalized["source_refs"] = _normalize_source_refs(normalized.get("source_refs"), contract, feature_id)
+    normalized["source_refs"] = _normalize_source_refs(
+        normalized.get("source_refs"),
+        contract,
+        feature_id,
+        rules_refs=rules_refs,
+    )
+    normalized["custom_rules"] = _normalize_custom_rules(loaded_rules)
 
     if commands and not normalize_string_list(normalized.get("autopilot_commands")):
         normalized["autopilot_commands"] = commands
@@ -139,10 +200,12 @@ def ensure_feature_contract(feature: dict, project_root: Path, state: dict) -> d
     return normalized
 
 
-def build_feature_packet(project_root: Path, state: dict, feature: dict) -> dict:
-    normalized = ensure_feature_contract(feature, project_root, state)
+def build_feature_packet(project_root: Path, state: dict, feature: dict, *, rules_context: dict | None = None) -> dict:
+    loaded_rules = rules_context or load_project_rules(project_root)
+    normalized = ensure_feature_contract(feature, project_root, state, rules_context=loaded_rules)
     contract = path_contract(project_root, state)
     commands, workdir, timeout = feature_execution_config(normalized)
+    rules_summary = _rules_summary(normalized.get("custom_rules") or {})
 
     snippets = {
         "think_summary": summarize_markdown(contract["artifacts"]["think"]),
@@ -150,6 +213,7 @@ def build_feature_packet(project_root: Path, state: dict, feature: dict) -> dict
         "requirements_summary": summarize_markdown(contract["artifacts"]["requirements"]),
         "design_summary": summarize_markdown(contract["artifacts"]["design"]),
         "tasks_summary": summarize_markdown(contract["artifacts"]["tasks"]),
+        "rules_summary": rules_summary,
     }
 
     return {
@@ -171,6 +235,7 @@ def build_feature_packet(project_root: Path, state: dict, feature: dict) -> dict
         "done_criteria": normalized.get("done_criteria") or [],
         "risk_notes": normalized.get("risk_notes") or [],
         "required_configs": normalized.get("required_configs") or [],
+        "custom_rules": normalized.get("custom_rules") or {},
         "source_refs": normalized.get("source_refs") or {},
         "source_snippets": snippets,
         "execution": {
@@ -203,11 +268,21 @@ def packet_validation_issues(packet: dict) -> list[str]:
         if not normalize_string_list(source_refs.get(key)):
             issues.append(f"source_refs.{key} is required.")
 
+    custom_rules = packet.get("custom_rules") if isinstance(packet.get("custom_rules"), dict) else {}
+    if custom_rules.get("enabled"):
+        if not normalize_string_list(source_refs.get("rules")):
+            issues.append("source_refs.rules is required when custom_rules are enabled.")
+        if not str(custom_rules.get("precedence_note") or "").strip():
+            issues.append("custom_rules.precedence_note is required when custom_rules are enabled.")
+        files = custom_rules.get("files")
+        if not isinstance(files, list) or not files:
+            issues.append("custom_rules.files must contain at least one rule when custom_rules are enabled.")
+
     return issues
 
 
-def write_feature_packet(project_root: Path, state: dict, feature: dict) -> Path:
-    packet = build_feature_packet(project_root, state, feature)
+def write_feature_packet(project_root: Path, state: dict, feature: dict, *, rules_context: dict | None = None) -> Path:
+    packet = build_feature_packet(project_root, state, feature, rules_context=rules_context)
     path = build_packet_path(project_root, state, feature.get("id"))
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(packet, indent=2, ensure_ascii=False), encoding="utf-8")
@@ -222,14 +297,18 @@ def load_feature_packet(project_root: Path, state: dict, feature_id: int | str) 
 
 
 def sync_feature_packets(project_root: Path, state: dict, payload: dict) -> dict:
-    normalized_features = [ensure_feature_contract(feature, project_root, state) for feature in payload.get("features", [])]
+    rules_context = load_project_rules(project_root)
+    normalized_features = [
+        ensure_feature_contract(feature, project_root, state, rules_context=rules_context)
+        for feature in payload.get("features", [])
+    ]
     payload["features"] = normalized_features
 
     packet_dir = path_contract(project_root, state)["packets_dir"]
     packet_dir.mkdir(parents=True, exist_ok=True)
     active_paths: set[Path] = set()
     for feature in normalized_features:
-        packet_path = write_feature_packet(project_root, state, feature)
+        packet_path = write_feature_packet(project_root, state, feature, rules_context=rules_context)
         active_paths.add(packet_path.resolve())
 
     for stale in packet_dir.glob("feature-*.json"):
@@ -257,6 +336,11 @@ def write_feature_result(project_root: Path, state: dict, result: dict, packet: 
             "commands": normalize_string_list((packet_data.get("execution") or {}).get("commands")),
             "passed": bool(result.get("ok")),
         },
+        "applied_rule_ids": [
+            str(rule.get("id") or "").strip()
+            for rule in ((packet_data.get("custom_rules") or {}).get("files") or [])
+            if str(rule.get("id") or "").strip()
+        ],
         "summary": result.get("detail") or "",
         "needs_clarification": False,
         "error": "" if result.get("ok") else result.get("detail") or "",

--- a/scripts/vibeflow_paths.py
+++ b/scripts/vibeflow_paths.py
@@ -248,6 +248,10 @@ def services_guide_path(project_root: Path) -> Path:
     return guides_dir(project_root) / "services.md"
 
 
+def project_rules_dir(project_root: Path) -> Path:
+    return project_root / "rules"
+
+
 def build_packets_root(project_root: Path) -> Path:
     return project_root / ".vibeflow" / "packets"
 
@@ -334,6 +338,7 @@ def path_contract(project_root: Path, state: dict | None = None) -> dict:
         "session_log": session_log_path(project_root),
         "build_guide": build_guide_path(project_root),
         "services_guide": services_guide_path(project_root),
+        "rules_dir": project_rules_dir(project_root),
         "change_root": change_root(project_root, loaded_state),
         "packets_dir": build_packets_dir(project_root, loaded_state),
         "packet_results_dir": build_packet_results_dir(project_root, loaded_state),

--- a/scripts/vibeflow_rules.py
+++ b/scripts/vibeflow_rules.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+SUPPORTED_RULE_SUFFIXES = {".md", ".markdown", ".txt", ".json", ".yaml", ".yml"}
+RULE_CONTENT_CHAR_LIMIT = 4000
+RULE_SUMMARY_CHAR_LIMIT = 320
+GUIDANCE_FILENAMES = {"claude.md", "agent.md", "agents.md"}
+
+
+def rules_dir_path(project_root: Path) -> Path:
+    return project_root / "rules"
+
+
+def guidance_file_paths(project_root: Path) -> list[Path]:
+    if not project_root.exists():
+        return []
+    return sorted(
+        [
+            path
+            for path in project_root.iterdir()
+            if path.is_file() and path.name.lower() in GUIDANCE_FILENAMES
+        ],
+        key=lambda path: path.name.lower(),
+    )
+
+
+def _relative_posix(path: Path, project_root: Path) -> str:
+    return path.relative_to(project_root).as_posix()
+
+
+def _truncate(value: str, limit: int) -> str:
+    text = value.strip()
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3].rstrip() + "..."
+
+
+def _slugify(value: str) -> str:
+    text = value.lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    return text.strip("-") or "rule"
+
+
+def _first_meaningful_line(content: str) -> str:
+    for raw in content.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("<!--"):
+            continue
+        return line
+    return ""
+
+
+def _extract_structured_value(content: str, keys: tuple[str, ...]) -> str:
+    for raw in content.splitlines():
+        line = raw.strip()
+        for key in keys:
+            match = re.match(rf"{re.escape(key)}\s*:\s*(.+)$", line, re.IGNORECASE)
+            if not match:
+                continue
+            value = match.group(1).strip().strip("\"'")
+            if value:
+                return value
+    return ""
+
+
+def _parse_json_metadata(content: str) -> tuple[str, str]:
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError:
+        return "", ""
+    if not isinstance(data, dict):
+        return "", ""
+    rule_id = str(data.get("rule_id") or data.get("id") or data.get("name") or "").strip()
+    title = str(data.get("title") or data.get("name") or data.get("id") or "").strip()
+    return rule_id, title
+
+
+def _extract_rule_id(path: Path, content: str, relative_path: str) -> str:
+    if path.suffix.lower() == ".json":
+        rule_id, _ = _parse_json_metadata(content)
+        if rule_id:
+            return _slugify(rule_id)
+    if path.suffix.lower() in {".yaml", ".yml"}:
+        rule_id = _extract_structured_value(content, ("rule_id", "id", "name"))
+        if rule_id:
+            return _slugify(rule_id)
+    return _slugify(relative_path.rsplit(".", 1)[0].replace("/", "-"))
+
+
+def _extract_title(path: Path, content: str) -> str:
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        _, title = _parse_json_metadata(content)
+        if title:
+            return title
+    if suffix in {".yaml", ".yml"}:
+        title = _extract_structured_value(content, ("title", "name", "id"))
+        if title:
+            return title
+    for raw in content.splitlines():
+        line = raw.strip()
+        if line.startswith("#"):
+            title = line.lstrip("#").strip()
+            if title:
+                return title
+    first_line = _first_meaningful_line(content)
+    if first_line:
+        return first_line.strip("\"'")
+    return path.stem.replace("-", " ").replace("_", " ").strip() or path.name
+
+
+def _summarize_content(content: str) -> str:
+    lines: list[str] = []
+    for raw in content.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("#"):
+            line = line.lstrip("#").strip()
+        lines.append(line)
+        if len(" ".join(lines)) >= RULE_SUMMARY_CHAR_LIMIT:
+            break
+    return _truncate(" ".join(lines), RULE_SUMMARY_CHAR_LIMIT)
+
+
+def load_project_rules(project_root: Path) -> dict:
+    rules_dir = rules_dir_path(project_root)
+    rule_files: list[dict] = []
+    guidance_files = [_relative_posix(path, project_root) for path in guidance_file_paths(project_root)]
+
+    if rules_dir.exists():
+        for path in sorted(rules_dir.rglob("*")):
+            if not path.is_file() or path.suffix.lower() not in SUPPORTED_RULE_SUFFIXES:
+                continue
+            content = path.read_text(encoding="utf-8")
+            relative_path = _relative_posix(path, project_root)
+            rule_files.append(
+                {
+                    "id": _extract_rule_id(path, content, relative_path),
+                    "title": _extract_title(path, content),
+                    "path": relative_path,
+                    "format": path.suffix.lower().lstrip("."),
+                    "summary": _summarize_content(content),
+                    "content": _truncate(content, RULE_CONTENT_CHAR_LIMIT),
+                }
+            )
+
+    precedence_targets = ", ".join(guidance_files) if guidance_files else "root agent guidance files"
+    return {
+        "enabled": bool(rule_files),
+        "rules_dir": _relative_posix(rules_dir, project_root),
+        "agent_guidance_files": guidance_files,
+        "precedence_note": (
+            f"Project rules under rules/ override {precedence_targets} when they conflict."
+        ),
+        "files": rule_files,
+    }

--- a/tests/test_vibeflow_autopilot.py
+++ b/tests/test_vibeflow_autopilot.py
@@ -406,6 +406,19 @@ class TestVibeFlowAutopilot:
         write_text(change_root / "requirements.md", "# Requirements\n\n- FR-001 Auth flow\n- FR-002 Audit trail\n")
         write_text(change_root / "design.md", "# Design\n\n## 4.1 Auth\n\nImplement auth.\n\n## 4.2 Audit\n\nImplement audit.\n")
         write_text(change_root / "design-review.md", "# Design Review\n\nApproved.\n")
+        write_text(project_root / "rules" / "implementation.md", "# Implementation Rules\n\nPrefer explicit adapters over inline API glue.\n")
+        write_text(
+            project_root / "rules" / "api.json",
+            json.dumps(
+                {
+                    "id": "api-contract",
+                    "title": "API Contract",
+                    "rules": ["Do not rename public response fields without a migration note."],
+                },
+                ensure_ascii=False,
+            ),
+        )
+        write_text(project_root / "CLAUDE.md", "# Global Guidance\n\nKeep examples short.\n")
         write_text(
             project_root / ".vibeflow" / "workflow.yaml",
             'name: "Packet Build Init"\ntemplate: "api-standard"\n',
@@ -435,8 +448,16 @@ class TestVibeFlowAutopilot:
         packet = read_json(packet_path)
         assert packet["feature"]["id"] == 1
         assert packet["objective"] == "Implement auth flow"
+        assert packet["custom_rules"]["enabled"] is True
+        assert packet["custom_rules"]["agent_guidance_files"] == ["CLAUDE.md"]
+        assert [item["id"] for item in packet["custom_rules"]["files"]] == [
+            "api-contract",
+            "rules-implementation",
+        ]
+        assert packet["source_refs"]["rules"] == ["rules/api.json", "rules/implementation.md"]
         assert packet["source_snippets"]["requirements_summary"]
         assert packet["source_snippets"]["design_summary"]
+        assert packet["source_snippets"]["rules_summary"]
 
     def test_autopilot_waits_at_manual_phase(self, tmp_path):
         project_root = tmp_path / "manual-stop-project"
@@ -589,6 +610,35 @@ class TestVibeFlowAutopilot:
         review_text = review_artifact.read_text(encoding="utf-8")
         assert "Feature #2 (Feature B): implementation result file is missing." in review_text
         assert "FAIL — Fix review issues before system testing." in review_text
+
+    def test_review_blocks_when_project_rules_are_missing_from_packet(self, tmp_path):
+        project_root = create_parallel_project(tmp_path)
+        write_text(project_root / "rules" / "api.md", "# API Rules\n\nKeep the summary payload stable.\n")
+
+        build_result = run_build_work(project_root, "--max-workers", 2)
+        assert build_result["ok"] is True
+
+        state = read_json(project_root / ".vibeflow" / "state.json")
+        packet_dir = project_root / ".vibeflow" / "packets" / state["active_change"]["id"]
+        packet_path = packet_dir / "feature-1.json"
+        packet = read_json(packet_path)
+        packet.pop("custom_rules", None)
+        packet["source_refs"].pop("rules", None)
+        write_json(packet_path, packet)
+
+        state["current_phase"] = "review"
+        state["checkpoints"]["build_work"] = True
+        state["checkpoints"]["review"] = False
+        write_json(project_root / ".vibeflow" / "state.json", state)
+
+        result = run_autopilot(project_root, expect_ok=False)
+        assert result["status"] == "blocked"
+        assert result["final_phase"] == "review"
+
+        review_artifact = project_root / state["artifacts"]["review"]
+        assert review_artifact.exists()
+        review_text = review_artifact.read_text(encoding="utf-8")
+        assert "custom rules exist in rules/ but were not injected into the implementation packet." in review_text
 
     def test_parallel_build_falls_back_to_serial_when_file_scope_overlaps(self, tmp_path):
         project_root = create_conflicting_parallel_project(tmp_path)

--- a/tests/test_vibeflow_v2.py
+++ b/tests/test_vibeflow_v2.py
@@ -23,6 +23,7 @@ phase_module = load_module("get-vibeflow-phase.py", "get_vibeflow_phase_v2")
 paths_module = load_module("vibeflow_paths.py", "vibeflow_paths_v2")
 st_module = load_module("check_st_readiness.py", "check_st_readiness_v2")
 migrate_module = load_module("migrate-vibeflow-v2.py", "migrate_vibeflow_v2")
+rules_module = load_module("vibeflow_rules.py", "vibeflow_rules_v2")
 
 
 detect_phase = phase_module.detect_phase
@@ -32,6 +33,7 @@ path_contract = paths_module.path_contract
 check_st_readiness = st_module.check_st_readiness
 mode_selection_required = paths_module.mode_selection_required
 selected_mode = paths_module.selected_mode
+load_project_rules = rules_module.load_project_rules
 
 
 def write(path: Path, content: str) -> None:
@@ -78,6 +80,7 @@ class TestVibeFlowV2:
         save_state(tmp_path, state)
 
         contract = path_contract(tmp_path, state)
+        assert contract["rules_dir"].name == "rules"
         assert contract["packets_dir"].name == state["active_change"]["id"]
         assert contract["packet_results_dir"].name == state["active_change"]["id"]
         assert contract["packets_dir"].parent.name == "packets"
@@ -92,6 +95,34 @@ class TestVibeFlowV2:
         assert contract["overview"]["product"].name == "PRODUCT.md"
         assert contract["overview"]["architecture"].name == "ARCHITECTURE.md"
         assert contract["overview"]["current_state"].name == "CURRENT-STATE.md"
+
+    def test_load_project_rules_reads_root_rules_and_tracks_guidance_precedence(self, tmp_path):
+        write(tmp_path / "rules" / "api-contract.md", "# API Contract\n\nDo not rename public response fields.\n")
+        write(
+            tmp_path / "rules" / "nested" / "ui.json",
+            json.dumps(
+                {
+                    "id": "ui-tone",
+                    "title": "UI Tone",
+                    "rules": ["Avoid generic placeholder copy."],
+                },
+                ensure_ascii=False,
+            ),
+        )
+        write(tmp_path / "CLAUDE.md", "# Global Guidance\n\nPrefer concise commits.\n")
+        write(tmp_path / "notes.txt", "not a rules file")
+
+        rules = load_project_rules(tmp_path)
+
+        assert rules["enabled"] is True
+        assert rules["rules_dir"] == "rules"
+        assert rules["agent_guidance_files"] == ["CLAUDE.md"]
+        assert "override CLAUDE.md" in rules["precedence_note"]
+        assert [item["path"] for item in rules["files"]] == [
+            "rules/api-contract.md",
+            "rules/nested/ui.json",
+        ]
+        assert [item["id"] for item in rules["files"]] == ["rules-api-contract", "ui-tone"]
 
     def test_init_project_creates_overview_docs(self, tmp_path):
         project_root = tmp_path / "overview-project"


### PR DESCRIPTION
## Summary
- add project-root `rules/` loading so custom rule files can augment spec-side execution inputs
- inject detected rules into feature packets with explicit precedence over root `CLAUDE.md` / `AGENT.md` guidance
- extend review checks and docs/tests so packet generation and review fail when rules are not carried into the execution contract

## Testing
- python -m pytest tests -q
- python -m unittest discover -s validation/sample-priority-api/tests -v
- python scripts/get-vibeflow-phase.py --project-root validation/sample-priority-api --json
- python scripts/test-vibeflow-setup.py --project-root validation/sample-priority-api --json