### PR TITLE
feat: add phase invariant policy engine

### DIFF
--- a/.vibeflow/policy.yaml
+++ b/.vibeflow/policy.yaml
@@ -1,0 +1,50 @@
+version: 1
+phases:
+  think:
+    required_artifacts: ["think"]
+    required_checkpoints: []
+    required_approvals: ["think"]
+    completion_evidence: ["artifact:think"]
+    blocking_conditions: []
+  plan:
+    required_artifacts: ["plan"]
+    required_checkpoints: []
+    required_approvals: ["plan"]
+    completion_evidence: ["artifact:plan"]
+    blocking_conditions: []
+  requirements:
+    required_artifacts: ["requirements"]
+    required_checkpoints: []
+    required_approvals: ["requirements"]
+    completion_evidence: ["artifact:requirements"]
+    blocking_conditions: []
+  design:
+    required_artifacts: ["design", "design_review"]
+    required_checkpoints: []
+    required_approvals: ["design"]
+    completion_evidence: ["artifact:design", "artifact:design_review"]
+    blocking_conditions: []
+  build-init:
+    required_artifacts: ["feature_list"]
+    required_checkpoints: []
+    required_approvals: []
+    completion_evidence: ["active_features", "build_init_ready_signal"]
+    blocking_conditions: []
+  review:
+    required_artifacts: ["review"]
+    required_checkpoints: []
+    required_approvals: ["review"]
+    completion_evidence: ["artifact:review"]
+    blocking_conditions: []
+  test-system:
+    required_artifacts: ["system_test"]
+    required_checkpoints: []
+    required_approvals: ["test_system"]
+    completion_evidence: ["artifact:system_test"]
+    blocking_conditions: []
+  ship:
+    required_artifacts: ["release_notes"]
+    required_checkpoints: []
+    required_approvals: ["ship"]
+    completion_evidence: ["release_notes_exists"]
+    blocking_conditions: []

--- a/scripts/get-vibeflow-phase.py
+++ b/scripts/get-vibeflow-phase.py
@@ -12,13 +12,18 @@ if str(SCRIPT_DIR) not in sys.path:
 from vibeflow_paths import (  # noqa: E402
     checkpoint_done,
     increment_queue_path,
+    load_policy,
+    load_runtime,
     load_state,
     path_contract,
     quick_meta,
     quick_readiness_issues,
+    save_runtime,
+    set_runtime_invariant,
     state_path,
     workflow_path,
 )
+from validate_phase_invariants import validate_phase  # noqa: E402
 
 
 def latest_matching_file(base: Path, pattern: str):
@@ -116,6 +121,59 @@ def increment_pending(project_root: Path) -> bool:
     return legacy_increment.exists()
 
 
+def append_invariant_checks(checks: list, validation: dict) -> None:
+    for entry in validation.get("checks", []):
+        checks.append(
+            (
+                f'{validation.get("phase")}:{entry.get("category")}:{entry.get("item")}',
+                not entry.get("ok", False),
+                entry.get("detail", ""),
+            )
+        )
+
+
+def apply_invariant_block(validation: dict, checks: list | None = None) -> tuple[str, str, str, str, dict]:
+    if checks is not None:
+        append_invariant_checks(checks, validation)
+    return (
+        validation["phase"],
+        validation["friendly_reason"],
+        validation.get("reason_code", ""),
+        validation.get("blocking_item", ""),
+        validation,
+    )
+
+
+def sync_runtime_from_detect(project_root: Path, result: dict) -> None:
+    if not state_path(project_root).exists():
+        return
+    runtime = load_runtime(project_root)
+    phase = result.get("phase", "")
+    reason = result.get("reason", "")
+    reason_code = result.get("reason_code", "")
+    status = "clear" if phase == "done" else ("blocked" if reason_code else "pending")
+    invariant_phase = "" if phase == "done" else phase
+    invariant_reason = "" if phase == "done" else reason
+    current_invariant = runtime.get("invariant") or {}
+    if (
+        runtime.get("current_phase") == phase
+        and current_invariant.get("phase") == invariant_phase
+        and current_invariant.get("reason") == invariant_reason
+        and current_invariant.get("reason_code") == reason_code
+        and current_invariant.get("status") == status
+    ):
+        return
+    runtime["current_phase"] = phase
+    set_runtime_invariant(
+        runtime,
+        phase=invariant_phase,
+        reason=invariant_reason,
+        reason_code=reason_code,
+        status=status,
+    )
+    save_runtime(project_root, runtime)
+
+
 def legacy_detect_phase(project_root: Path, verbose: bool = False) -> dict:
     state_root = project_root / ".vibeflow"
     think_path = state_root / "think-output.md"
@@ -159,6 +217,9 @@ def legacy_detect_phase(project_root: Path, verbose: bool = False) -> dict:
 
     phase = "done"
     reason = "All detectable phases completed."
+    reason_code = ""
+    blocking_item = ""
+    invariant = {}
 
     if quick_config_path.exists() and not quick_design_path.exists():
         phase, reason = "quick", "docs/quick-design.md is missing."
@@ -200,6 +261,9 @@ def legacy_detect_phase(project_root: Path, verbose: bool = False) -> dict:
     result = {
         "phase": phase,
         "reason": reason,
+        "reason_code": "",
+        "blocking_item": "",
+        "invariant": {},
         "has_ui": _ui_req,
         "ship_required": _ship_req,
         "reflect_required": _reflect_req,
@@ -227,6 +291,7 @@ def legacy_detect_phase(project_root: Path, verbose: bool = False) -> dict:
 def state_based_detect_phase(project_root: Path, verbose: bool = False) -> dict:
     state = load_state(project_root)
     contract = path_contract(project_root, state)
+    policy = load_policy(project_root)
     workflow_path_obj = contract["workflow"]
     feature_list = contract["feature_list"]
     work_config = contract["work_config"]
@@ -285,6 +350,12 @@ def state_based_detect_phase(project_root: Path, verbose: bool = False) -> dict:
 
     phase = "done"
     reason = "All detectable phases completed."
+    reason_code = ""
+    blocking_item = ""
+    invariant = {}
+
+    def evaluate_invariant(phase_name: str) -> dict:
+        return validate_phase(project_root, phase_name, state=state, contract=contract, policy=policy)
 
     if is_quick_mode and quick_issues:
         phase = "quick"
@@ -299,46 +370,97 @@ def state_based_detect_phase(project_root: Path, verbose: bool = False) -> dict:
             phase, reason = "build-work", "Quick mode is ready and should proceed directly into build."
         elif not all_features_passing(feature_list):
             phase, reason = "build-work", "Quick mode has unfinished features."
-        elif not checkpoint_done(state, "review") or not artifacts["review"].exists():
-            phase, reason = "review", "Global review artifact is missing or not approved."
-        elif not checkpoint_done(state, "test_system") or not artifacts["system_test"].exists():
-            phase, reason = "test-system", "System test artifact is missing or not approved."
-        elif _ui_req and (not checkpoint_done(state, "test_qa") or not artifacts["qa"].exists()):
-            phase, reason = "test-qa", "UI workflow requires QA artifact."
-        elif _ship_req and (not checkpoint_done(state, "ship") or not release_notes.exists()):
-            phase, reason = "ship", "Ship is required and release notes are missing."
-        elif _reflect_req and (not checkpoint_done(state, "reflect") or latest_retro is None):
-            phase, reason = "reflect", "Reflect is required and no retrospective exists."
-    elif not checkpoint_done(state, "think") or not artifacts["think"].exists():
-        phase, reason = "think", "Think artifact is missing or not approved."
-    elif not workflow_path_obj.exists():
-        phase, reason = "template-selection", "Workflow file is missing."
-    elif not checkpoint_done(state, "plan") or not artifacts["plan"].exists():
-        phase, reason = "plan", "Plan artifact is missing or not approved."
-    elif not checkpoint_done(state, "requirements") or not artifacts["requirements"].exists():
-        phase, reason = "requirements", "Requirements artifact is missing or not approved."
-    elif not checkpoint_done(state, "design") or not artifacts["design"].exists() or not artifacts["design_review"].exists():
-        phase, reason = "design", "Design or design review artifact is missing or not approved."
-    elif not build_init_ready:
-        phase, reason = "build-init", "feature-list.json is missing, empty, or no build-init readiness signal exists."
-    elif not work_config.exists():
-        phase, reason = "build-config", ".vibeflow/work-config.json is missing."
-    elif not all_features_passing(feature_list):
-        phase, reason = "build-work", "Some active features are not passing."
-    elif not checkpoint_done(state, "review") or not artifacts["review"].exists():
-        phase, reason = "review", "Global review artifact is missing or not approved."
-    elif not checkpoint_done(state, "test_system") or not artifacts["system_test"].exists():
-        phase, reason = "test-system", "System test artifact is missing or not approved."
-    elif _ui_req and (not checkpoint_done(state, "test_qa") or not artifacts["qa"].exists()):
-        phase, reason = "test-qa", "UI workflow requires QA artifact."
-    elif _ship_req and (not checkpoint_done(state, "ship") or not release_notes.exists()):
-        phase, reason = "ship", "Ship is required and release notes are missing."
-    elif _reflect_req and (not checkpoint_done(state, "reflect") or latest_retro is None):
-        phase, reason = "reflect", "Reflect is required and no retrospective exists."
+        else:
+            review_validation = evaluate_invariant("review")
+            if not review_validation["ok"]:
+                phase, reason, reason_code, blocking_item, invariant = apply_invariant_block(review_validation, checks if verbose else None)
+            else:
+                test_validation = evaluate_invariant("test-system")
+                if not test_validation["ok"]:
+                    phase, reason, reason_code, blocking_item, invariant = apply_invariant_block(test_validation, checks if verbose else None)
+                elif _ui_req and (not checkpoint_done(state, "test_qa") or not artifacts["qa"].exists()):
+                    phase, reason = "test-qa", "UI workflow requires QA artifact."
+                    if not artifacts["qa"].exists():
+                        reason_code = "missing_artifact"
+                        blocking_item = "qa"
+                    elif not checkpoint_done(state, "test_qa"):
+                        reason_code = "missing_approval"
+                        blocking_item = "test_qa"
+                elif _ship_req:
+                    ship_validation = evaluate_invariant("ship")
+                    if not ship_validation["ok"]:
+                        phase, reason, reason_code, blocking_item, invariant = apply_invariant_block(ship_validation, checks if verbose else None)
+                    elif _reflect_req and (not checkpoint_done(state, "reflect") or latest_retro is None):
+                        phase, reason = "reflect", "Reflect is required and no retrospective exists."
+                        reason_code = "missing_completion_evidence"
+                        blocking_item = "reflect"
+                elif _reflect_req and (not checkpoint_done(state, "reflect") or latest_retro is None):
+                    phase, reason = "reflect", "Reflect is required and no retrospective exists."
+                    reason_code = "missing_completion_evidence"
+                    blocking_item = "reflect"
+    else:
+        think_validation = evaluate_invariant("think")
+        if not think_validation["ok"]:
+            phase, reason, reason_code, blocking_item, invariant = apply_invariant_block(think_validation, checks if verbose else None)
+        elif not workflow_path_obj.exists():
+            phase, reason = "template-selection", "Workflow file is missing."
+        else:
+            plan_validation = evaluate_invariant("plan")
+            if not plan_validation["ok"]:
+                phase, reason, reason_code, blocking_item, invariant = apply_invariant_block(plan_validation, checks if verbose else None)
+            else:
+                requirements_validation = evaluate_invariant("requirements")
+                if not requirements_validation["ok"]:
+                    phase, reason, reason_code, blocking_item, invariant = apply_invariant_block(requirements_validation, checks if verbose else None)
+                else:
+                    design_validation = evaluate_invariant("design")
+                    if not design_validation["ok"]:
+                        phase, reason, reason_code, blocking_item, invariant = apply_invariant_block(design_validation, checks if verbose else None)
+                    else:
+                        build_init_validation = evaluate_invariant("build-init")
+                        if not build_init_validation["ok"]:
+                            phase, reason, reason_code, blocking_item, invariant = apply_invariant_block(build_init_validation, checks if verbose else None)
+                        elif not work_config.exists():
+                            phase, reason = "build-config", ".vibeflow/work-config.json is missing."
+                            reason_code = "missing_artifact"
+                            blocking_item = "work_config"
+                        elif not all_features_passing(feature_list):
+                            phase, reason = "build-work", "Some active features are not passing."
+                        else:
+                            review_validation = evaluate_invariant("review")
+                            if not review_validation["ok"]:
+                                phase, reason, reason_code, blocking_item, invariant = apply_invariant_block(review_validation, checks if verbose else None)
+                            else:
+                                test_validation = evaluate_invariant("test-system")
+                                if not test_validation["ok"]:
+                                    phase, reason, reason_code, blocking_item, invariant = apply_invariant_block(test_validation, checks if verbose else None)
+                                elif _ui_req and (not checkpoint_done(state, "test_qa") or not artifacts["qa"].exists()):
+                                    phase, reason = "test-qa", "UI workflow requires QA artifact."
+                                    if not artifacts["qa"].exists():
+                                        reason_code = "missing_artifact"
+                                        blocking_item = "qa"
+                                    elif not checkpoint_done(state, "test_qa"):
+                                        reason_code = "missing_approval"
+                                        blocking_item = "test_qa"
+                                elif _ship_req:
+                                    ship_validation = evaluate_invariant("ship")
+                                    if not ship_validation["ok"]:
+                                        phase, reason, reason_code, blocking_item, invariant = apply_invariant_block(ship_validation, checks if verbose else None)
+                                    elif _reflect_req and (not checkpoint_done(state, "reflect") or latest_retro is None):
+                                        phase, reason = "reflect", "Reflect is required and no retrospective exists."
+                                        reason_code = "missing_completion_evidence"
+                                        blocking_item = "reflect"
+                                elif _reflect_req and (not checkpoint_done(state, "reflect") or latest_retro is None):
+                                    phase, reason = "reflect", "Reflect is required and no retrospective exists."
+                                    reason_code = "missing_completion_evidence"
+                                    blocking_item = "reflect"
 
     result = {
         "phase": phase,
         "reason": reason,
+        "reason_code": reason_code,
+        "blocking_item": blocking_item,
+        "invariant": invariant,
         "has_ui": _ui_req,
         "ship_required": _ship_req,
         "reflect_required": _reflect_req,
@@ -369,10 +491,16 @@ def state_based_detect_phase(project_root: Path, verbose: bool = False) -> dict:
     return result
 
 
-def detect_phase(project_root: Path, verbose: bool = False) -> dict:
+def detect_phase(project_root: Path, verbose: bool = False, sync_runtime: bool = False) -> dict:
     if state_path(project_root).exists():
-        return state_based_detect_phase(project_root, verbose=verbose)
-    return legacy_detect_phase(project_root, verbose=verbose)
+        result = state_based_detect_phase(project_root, verbose=verbose)
+        if sync_runtime:
+            sync_runtime_from_detect(project_root, result)
+        return result
+    result = legacy_detect_phase(project_root, verbose=verbose)
+    if sync_runtime:
+        sync_runtime_from_detect(project_root, result)
+    return result
 
 
 def main():
@@ -381,7 +509,7 @@ def main():
     parser.add_argument("--json", action="store_true", dest="as_json")
     parser.add_argument("--verbose", action="store_true")
     args = parser.parse_args()
-    result = detect_phase(Path(args.project_root).resolve(), verbose=args.verbose)
+    result = detect_phase(Path(args.project_root).resolve(), verbose=args.verbose, sync_runtime=True)
     if args.as_json:
         print(json.dumps(result, indent=2, ensure_ascii=False))
     else:

--- a/scripts/validate_phase_invariants.py
+++ b/scripts/validate_phase_invariants.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from vibeflow_paths import checkpoint_done, load_policy, load_state, path_contract  # noqa: E402
+
+
+PHASE_LABELS = {
+    "think": "Think",
+    "plan": "Plan",
+    "requirements": "Requirements",
+    "design": "Design",
+    "build-init": "Build init",
+    "review": "Review",
+    "test-system": "System test",
+    "ship": "Ship",
+}
+
+ARTIFACT_LABELS = {
+    "think": "Think artifact",
+    "plan": "Plan artifact",
+    "requirements": "Requirements artifact",
+    "design": "Design artifact",
+    "design_review": "Design review artifact",
+    "review": "Review artifact",
+    "system_test": "System test artifact",
+    "qa": "QA artifact",
+    "feature_list": "feature-list.json",
+    "work_config": ".vibeflow/work-config.json",
+    "release_notes": "RELEASE_NOTES.md",
+}
+
+CHECKPOINT_LABELS = {
+    "think": "think checkpoint",
+    "plan": "plan checkpoint",
+    "requirements": "requirements checkpoint",
+    "design": "design checkpoint",
+    "build_init": "build-init checkpoint",
+    "review": "review checkpoint",
+    "test_system": "test-system checkpoint",
+    "test_qa": "test-qa checkpoint",
+    "ship": "ship checkpoint",
+    "reflect": "reflect checkpoint",
+}
+
+BLOCKING_LABELS = {
+    "pending_increment": "increment queue has pending items",
+}
+
+EVIDENCE_LABELS = {
+    "active_features": "active features declared in feature-list.json",
+    "build_init_ready_signal": "build-init readiness signal",
+    "release_notes_exists": "release notes file",
+}
+
+
+def _load_feature_payload(feature_list_path: Path) -> dict:
+    if not feature_list_path.exists():
+        return {}
+    return json.loads(feature_list_path.read_text(encoding="utf-8"))
+
+
+def has_active_features(feature_list_path: Path) -> bool:
+    data = _load_feature_payload(feature_list_path)
+    features = [feature for feature in data.get("features", []) if not feature.get("deprecated")]
+    return bool(features)
+
+
+def build_packets_ready(feature_list_path: Path, packets_dir: Path) -> bool:
+    data = _load_feature_payload(feature_list_path)
+    features = [feature for feature in data.get("features", []) if not feature.get("deprecated")]
+    if not features:
+        return False
+    for feature in features:
+        feature_id = feature.get("id")
+        if feature_id is None:
+            continue
+        if not (packets_dir / f"feature-{feature_id}.json").exists():
+            return False
+    return True
+
+
+def artifact_lookup(contract: dict) -> dict[str, Path]:
+    lookup = dict(contract["artifacts"])
+    lookup["feature_list"] = contract["feature_list"]
+    lookup["work_config"] = contract["work_config"]
+    lookup["release_notes"] = contract["release_notes"]
+    return lookup
+
+
+def evaluate_blocking_condition(condition: str, *, project_root: Path, state: dict, contract: dict) -> tuple[bool, str]:
+    if condition == "pending_increment":
+        queue_path = contract["increment_queue"]
+        if queue_path.exists():
+            try:
+                data = json.loads(queue_path.read_text(encoding="utf-8"))
+                if isinstance(data, dict) and data.get("items"):
+                    return True, "increment queue still has pending items."
+                if isinstance(data, list) and data:
+                    return True, "increment queue still has pending items."
+            except json.JSONDecodeError:
+                return True, "increment queue exists but could not be parsed."
+        legacy_increment = project_root / ".vibeflow" / "increment-request.json"
+        if legacy_increment.exists():
+            return True, "legacy increment request is still present."
+        return False, "increment queue is empty."
+
+    return False, f"unknown blocking condition '{condition}' is not active."
+
+
+def evaluate_evidence(evidence: str, *, state: dict, contract: dict) -> tuple[bool, str]:
+    if evidence.startswith("artifact:"):
+        artifact_name = evidence.split(":", 1)[1]
+        path = artifact_lookup(contract).get(artifact_name)
+        exists = bool(path and path.exists())
+        label = ARTIFACT_LABELS.get(artifact_name, artifact_name)
+        return exists, f"{label} {'exists' if exists else 'is missing'}."
+
+    if evidence.startswith("checkpoint:"):
+        checkpoint_name = evidence.split(":", 1)[1]
+        ok = checkpoint_done(state, checkpoint_name)
+        label = CHECKPOINT_LABELS.get(checkpoint_name, checkpoint_name)
+        return ok, f"{label} {'is approved' if ok else 'is not approved'}."
+
+    if evidence == "active_features":
+        ok = has_active_features(contract["feature_list"])
+        return ok, "feature-list.json has active features." if ok else "feature-list.json has no active features."
+
+    if evidence == "build_init_ready_signal":
+        ok = (
+            checkpoint_done(state, "build_init")
+            or contract["work_config"].exists()
+            or build_packets_ready(contract["feature_list"], contract["packets_dir"])
+        )
+        return ok, (
+            "build-init readiness signal is present."
+            if ok
+            else "build-init readiness signal is missing (need build_init checkpoint, work-config, or packets)."
+        )
+
+    if evidence == "release_notes_exists":
+        ok = contract["release_notes"].exists()
+        return ok, "RELEASE_NOTES.md exists." if ok else "RELEASE_NOTES.md is missing."
+
+    return False, f"unknown evidence '{evidence}' is not satisfied."
+
+
+def _result_template(phase: str) -> dict:
+    return {
+        "phase": phase,
+        "phase_label": PHASE_LABELS.get(phase, phase),
+        "ok": True,
+        "status": "clear",
+        "reason_code": "",
+        "blocking_item": "",
+        "detail": "",
+        "friendly_reason": "",
+        "checks": [],
+    }
+
+
+def _failure(result: dict, *, reason_code: str, blocking_item: str, detail: str, friendly_reason: str) -> dict:
+    result["ok"] = False
+    result["status"] = "blocked"
+    result["reason_code"] = reason_code
+    result["blocking_item"] = blocking_item
+    result["detail"] = detail
+    result["friendly_reason"] = friendly_reason
+    return result
+
+
+def validate_phase(project_root: Path, phase: str, *, state: dict | None = None, contract: dict | None = None, policy: dict | None = None) -> dict:
+    loaded_state = state or load_state(project_root)
+    loaded_contract = contract or path_contract(project_root, loaded_state)
+    loaded_policy = policy or load_policy(project_root)
+    phase_policy = (loaded_policy.get("phases") or {}).get(phase) or {}
+    result = _result_template(phase)
+    lookup = artifact_lookup(loaded_contract)
+
+    for condition in phase_policy.get("blocking_conditions", []):
+        blocked, detail = evaluate_blocking_condition(
+            condition,
+            project_root=project_root,
+            state=loaded_state,
+            contract=loaded_contract,
+        )
+        result["checks"].append(
+            {
+                "category": "blocking_condition",
+                "item": condition,
+                "ok": not blocked,
+                "detail": detail,
+            }
+        )
+        if blocked:
+            return _failure(
+                result,
+                reason_code="blocking_condition",
+                blocking_item=condition,
+                detail=detail,
+                friendly_reason=f"{PHASE_LABELS.get(phase, phase)} is blocked because {detail}",
+            )
+
+    for artifact_name in phase_policy.get("required_artifacts", []):
+        path = lookup.get(artifact_name)
+        exists = bool(path and path.exists())
+        label = ARTIFACT_LABELS.get(artifact_name, artifact_name)
+        detail = f"{label} {'exists' if exists else 'is missing'}."
+        result["checks"].append(
+            {
+                "category": "required_artifact",
+                "item": artifact_name,
+                "ok": exists,
+                "detail": detail,
+            }
+        )
+        if not exists:
+            return _failure(
+                result,
+                reason_code="missing_artifact",
+                blocking_item=artifact_name,
+                detail=detail,
+                friendly_reason=f"{PHASE_LABELS.get(phase, phase)} cannot continue because {label} is missing.",
+            )
+
+    for checkpoint_name in phase_policy.get("required_checkpoints", []):
+        ok = checkpoint_done(loaded_state, checkpoint_name)
+        label = CHECKPOINT_LABELS.get(checkpoint_name, checkpoint_name)
+        detail = f"{label} {'is ready' if ok else 'is not ready'}."
+        result["checks"].append(
+            {
+                "category": "required_checkpoint",
+                "item": checkpoint_name,
+                "ok": ok,
+                "detail": detail,
+            }
+        )
+        if not ok:
+            return _failure(
+                result,
+                reason_code="missing_checkpoint",
+                blocking_item=checkpoint_name,
+                detail=detail,
+                friendly_reason=f"{PHASE_LABELS.get(phase, phase)} is waiting for {label}.",
+            )
+
+    for approval_name in phase_policy.get("required_approvals", []):
+        approved = checkpoint_done(loaded_state, approval_name)
+        label = CHECKPOINT_LABELS.get(approval_name, approval_name)
+        detail = f"{label} {'is approved' if approved else 'is not approved'}."
+        result["checks"].append(
+            {
+                "category": "required_approval",
+                "item": approval_name,
+                "ok": approved,
+                "detail": detail,
+            }
+        )
+        if not approved:
+            return _failure(
+                result,
+                reason_code="missing_approval",
+                blocking_item=approval_name,
+                detail=detail,
+                friendly_reason=f"{PHASE_LABELS.get(phase, phase)} is waiting for {label}.",
+            )
+
+    for evidence_name in phase_policy.get("completion_evidence", []):
+        ok, detail = evaluate_evidence(
+            evidence_name,
+            state=loaded_state,
+            contract=loaded_contract,
+        )
+        result["checks"].append(
+            {
+                "category": "completion_evidence",
+                "item": evidence_name,
+                "ok": ok,
+                "detail": detail,
+            }
+        )
+        if not ok:
+            label = EVIDENCE_LABELS.get(evidence_name, evidence_name)
+            return _failure(
+                result,
+                reason_code="missing_completion_evidence",
+                blocking_item=evidence_name,
+                detail=detail,
+                friendly_reason=f"{PHASE_LABELS.get(phase, phase)} is waiting for {label}.",
+            )
+
+    result["detail"] = f"{PHASE_LABELS.get(phase, phase)} invariants are satisfied."
+    result["friendly_reason"] = result["detail"]
+    return result
+
+
+def validate_phase_invariants(project_root: Path, phase: str | None = None) -> dict:
+    project_root = project_root.resolve()
+    state = load_state(project_root)
+    contract = path_contract(project_root, state)
+    policy = load_policy(project_root)
+
+    if phase:
+        return validate_phase(project_root, phase, state=state, contract=contract, policy=policy)
+
+    phases = []
+    for phase_name in (policy.get("phases") or {}).keys():
+        phases.append(validate_phase(project_root, phase_name, state=state, contract=contract, policy=policy))
+    return {
+        "ok": all(item["ok"] for item in phases),
+        "phases": phases,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project-root", default=".")
+    parser.add_argument("--phase")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+
+    result = validate_phase_invariants(Path(args.project_root), phase=args.phase)
+    if args.as_json:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return
+
+    if args.phase:
+        print(result["friendly_reason"])
+        return
+
+    if result["ok"]:
+        print("All configured phase invariants are satisfied.")
+        return
+
+    first_failed = next((item for item in result["phases"] if not item["ok"]), result["phases"][0])
+    print(first_failed["friendly_reason"])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/vibeflow_dashboard.py
+++ b/scripts/vibeflow_dashboard.py
@@ -207,11 +207,12 @@ def load_feature_summary(project_root: Path) -> dict:
 def build_dashboard_snapshot(project_root: Path) -> dict:
     project_root = project_root.resolve()
     state = load_state(project_root)
-    runtime = load_runtime(project_root)
     contract = path_contract(project_root, state)
-    detect_info = detect_phase(project_root)
+    detect_info = detect_phase(project_root, sync_runtime=True)
+    runtime = load_runtime(project_root)
     flags = required_flags(contract["workflow"])
     feature_summary = load_feature_summary(project_root)
+    invariant = runtime.get("invariant") or {}
 
     macro_cards = []
     for key, label, phases in PHASE_GROUPS:
@@ -292,10 +293,21 @@ def build_dashboard_snapshot(project_root: Path) -> dict:
 
     current_phase = detect_info["phase"]
     runtime_status = runtime.get("status") or ("completed" if current_phase == "done" else "idle")
-    friendly = runtime.get("friendly_message") or friendly_message_for_phase(
+    invariant_matches = (
+        current_phase != "done"
+        and invariant.get("phase") == current_phase
+        and bool(invariant.get("reason"))
+    )
+    if invariant_matches:
+        runtime_status = invariant.get("status") or runtime_status
+    stop_reason = runtime.get("stop_reason") or invariant.get("reason") or detect_info["reason"]
+    friendly_seed = runtime.get("friendly_message")
+    if invariant_matches and runtime_status in {"blocked", "pending"}:
+        friendly_seed = ""
+    friendly = friendly_seed or friendly_message_for_phase(
         current_phase,
         status="waiting_manual" if current_phase in {"think", "plan", "requirements", "design", "quick"} else runtime_status,
-        detail=detect_info["reason"],
+        detail=stop_reason,
     )
 
     return {
@@ -307,7 +319,8 @@ def build_dashboard_snapshot(project_root: Path) -> dict:
         "current_phase": current_phase,
         "status": runtime_status,
         "friendly_message": friendly,
-        "reason": detect_info["reason"],
+        "reason": stop_reason,
+        "reason_code": invariant.get("reason_code") or detect_info.get("reason_code", ""),
         "active_change": state.get("active_change") or {},
         "workflow": macro_cards,
         "features": feature_summary,
@@ -315,6 +328,7 @@ def build_dashboard_snapshot(project_root: Path) -> dict:
         "events": events,
         "checkpoints": state.get("checkpoints") or {},
         "runtime": runtime,
+        "invariant": invariant,
         "flags": flags,
     }
 

--- a/scripts/vibeflow_paths.py
+++ b/scripts/vibeflow_paths.py
@@ -50,6 +50,14 @@ DEFAULT_QUICK_PROMOTION_RULES = [
     "design decisions are no longer obvious",
 ]
 
+POLICY_PHASE_FIELDS = (
+    "required_artifacts",
+    "required_checkpoints",
+    "required_approvals",
+    "completion_evidence",
+    "blocking_conditions",
+)
+
 
 def slugify(value: str) -> str:
     cleaned = []
@@ -174,6 +182,10 @@ def workflow_path(project_root: Path) -> Path:
 
 def work_config_path(project_root: Path) -> Path:
     return project_root / ".vibeflow" / "work-config.json"
+
+
+def policy_path(project_root: Path) -> Path:
+    return project_root / ".vibeflow" / "policy.yaml"
 
 
 def feature_list_path(project_root: Path) -> Path:
@@ -315,6 +327,7 @@ def path_contract(project_root: Path, state: dict | None = None) -> dict:
     return {
         "state": state_path(project_root),
         "runtime": runtime_path(project_root),
+        "policy": policy_path(project_root),
         "workflow": workflow_path(project_root),
         "work_config": work_config_path(project_root),
         "feature_list": feature_list_path(project_root),
@@ -406,6 +419,175 @@ def selected_mode(project_root: Path) -> str | None:
     return mode or None
 
 
+def default_policy() -> dict:
+    return {
+        "version": 1,
+        "phases": {
+            "think": {
+                "required_artifacts": ["think"],
+                "required_checkpoints": [],
+                "required_approvals": ["think"],
+                "completion_evidence": ["artifact:think"],
+                "blocking_conditions": [],
+            },
+            "plan": {
+                "required_artifacts": ["plan"],
+                "required_checkpoints": [],
+                "required_approvals": ["plan"],
+                "completion_evidence": ["artifact:plan"],
+                "blocking_conditions": [],
+            },
+            "requirements": {
+                "required_artifacts": ["requirements"],
+                "required_checkpoints": [],
+                "required_approvals": ["requirements"],
+                "completion_evidence": ["artifact:requirements"],
+                "blocking_conditions": [],
+            },
+            "design": {
+                "required_artifacts": ["design", "design_review"],
+                "required_checkpoints": [],
+                "required_approvals": ["design"],
+                "completion_evidence": ["artifact:design", "artifact:design_review"],
+                "blocking_conditions": [],
+            },
+            "build-init": {
+                "required_artifacts": ["feature_list"],
+                "required_checkpoints": [],
+                "required_approvals": [],
+                "completion_evidence": ["active_features", "build_init_ready_signal"],
+                "blocking_conditions": [],
+            },
+            "review": {
+                "required_artifacts": ["review"],
+                "required_checkpoints": [],
+                "required_approvals": ["review"],
+                "completion_evidence": ["artifact:review"],
+                "blocking_conditions": [],
+            },
+            "test-system": {
+                "required_artifacts": ["system_test"],
+                "required_checkpoints": [],
+                "required_approvals": ["test_system"],
+                "completion_evidence": ["artifact:system_test"],
+                "blocking_conditions": [],
+            },
+            "ship": {
+                "required_artifacts": ["release_notes"],
+                "required_checkpoints": [],
+                "required_approvals": ["ship"],
+                "completion_evidence": ["release_notes_exists"],
+                "blocking_conditions": [],
+            },
+        },
+    }
+
+
+def _parse_policy_scalar(value: str):
+    if value == "":
+        return ""
+    if value.startswith("[") or value.startswith("{"):
+        return json.loads(value)
+    lowered = value.lower()
+    if lowered in {"true", "false"}:
+        return lowered == "true"
+    if value.startswith('"') and value.endswith('"'):
+        return json.loads(value)
+    if value.startswith("'") and value.endswith("'"):
+        return value[1:-1]
+    try:
+        return int(value)
+    except ValueError:
+        return value
+
+
+def _parse_policy_text(text: str) -> dict:
+    data: dict = {}
+    current_phase: str | None = None
+    in_phases = False
+
+    for raw_line in text.splitlines():
+        line = raw_line.split("#", 1)[0].rstrip()
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        stripped = line.strip()
+
+        if indent == 0:
+            current_phase = None
+            key, _, value = stripped.partition(":")
+            key = key.strip()
+            value = value.strip()
+            if key == "phases":
+                data["phases"] = {}
+                in_phases = True
+                continue
+            in_phases = False
+            data[key] = _parse_policy_scalar(value)
+            continue
+
+        if indent == 2 and in_phases and stripped.endswith(":"):
+            current_phase = stripped[:-1].strip()
+            data.setdefault("phases", {})[current_phase] = {}
+            continue
+
+        if indent == 4 and in_phases and current_phase:
+            key, _, value = stripped.partition(":")
+            data["phases"][current_phase][key.strip()] = _parse_policy_scalar(value.strip())
+            continue
+
+        raise ValueError(f"Unsupported policy syntax: {raw_line}")
+
+    return data
+
+
+def _normalize_policy_list(value) -> list[str]:
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str) and value.strip():
+        return [value.strip()]
+    return []
+
+
+def load_policy(project_root: Path) -> dict:
+    merged = deepcopy(default_policy())
+    path = policy_path(project_root)
+    if not path.exists():
+        return merged
+
+    loaded = _parse_policy_text(path.read_text(encoding="utf-8"))
+    version = loaded.get("version")
+    if isinstance(version, int):
+        merged["version"] = version
+
+    phases = loaded.get("phases") or {}
+    if not isinstance(phases, dict):
+        return merged
+
+    for phase_name, config in phases.items():
+        if not isinstance(config, dict):
+            continue
+        target = merged["phases"].setdefault(
+            phase_name,
+            {field: [] for field in POLICY_PHASE_FIELDS},
+        )
+        for field in POLICY_PHASE_FIELDS:
+            if field in config:
+                target[field] = _normalize_policy_list(config.get(field))
+
+    return merged
+
+
+def default_runtime_invariant() -> dict:
+    return {
+        "phase": "",
+        "reason": "",
+        "reason_code": "",
+        "status": "clear",
+        "updated_at": "",
+    }
+
+
 def default_runtime() -> dict:
     return {
         "run_id": "",
@@ -420,6 +602,7 @@ def default_runtime() -> dict:
         "events": [],
         "phase_runs": [],
         "feature_runs": [],
+        "invariant": default_runtime_invariant(),
     }
 
 
@@ -429,8 +612,14 @@ def load_runtime(project_root: Path) -> dict:
         return default_runtime()
     data = json.loads(path.read_text(encoding="utf-8"))
     merged = default_runtime()
-    merged.update({k: v for k, v in data.items() if k not in {"attempts", "events", "phase_runs", "feature_runs"}})
-    for key in ("attempts", "events", "phase_runs", "feature_runs"):
+    merged.update(
+        {
+            k: v
+            for k, v in data.items()
+            if k not in {"attempts", "events", "phase_runs", "feature_runs", "invariant"}
+        }
+    )
+    for key in ("attempts", "events", "phase_runs", "feature_runs", "invariant"):
         loaded = data.get(key)
         if isinstance(loaded, dict) and isinstance(merged.get(key), dict):
             merged[key].update(loaded)
@@ -452,6 +641,32 @@ def ensure_runtime(project_root: Path) -> dict:
         return load_runtime(project_root)
     runtime = default_runtime()
     save_runtime(project_root, runtime)
+    return runtime
+
+
+def set_runtime_invariant(
+    runtime: dict,
+    *,
+    phase: str = "",
+    reason: str = "",
+    reason_code: str = "",
+    status: str = "clear",
+    updated_at: str | None = None,
+) -> dict:
+    invariant = deepcopy(default_runtime_invariant())
+    loaded = runtime.get("invariant")
+    if isinstance(loaded, dict):
+        invariant.update(loaded)
+    invariant.update(
+        {
+            "phase": phase,
+            "reason": reason,
+            "reason_code": reason_code,
+            "status": status,
+            "updated_at": updated_at or datetime.now().astimezone().isoformat(timespec="seconds"),
+        }
+    )
+    runtime["invariant"] = invariant
     return runtime
 
 

--- a/tests/test_vibeflow_dashboard.py
+++ b/tests/test_vibeflow_dashboard.py
@@ -35,6 +35,11 @@ def write_json(path: Path, data: object) -> None:
     path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
 
 
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
 def fetch_text(url: str) -> str:
     with urllib.request.urlopen(url) as response:
         return response.read().decode("utf-8")
@@ -87,3 +92,17 @@ class TestVibeFlowDashboard:
         snapshot_after = build_dashboard_snapshot(project_root)
         assert snapshot_before["token"] != snapshot_after["token"]
         assert snapshot_after["friendly_message"] == "正在准备新的演示快照。"
+
+    def test_dashboard_surfaces_invariant_stop_reason(self, tmp_path):
+        project_root = copy_sample_project(tmp_path, "dashboard-invariant")
+        state_path = project_root / ".vibeflow" / "state.json"
+        state = read_json(state_path)
+        state["checkpoints"]["review"] = False
+        write_json(state_path, state)
+        write_text(project_root / state["artifacts"]["review"], "# Review\n\nPending approval.\n")
+
+        snapshot = build_dashboard_snapshot(project_root)
+        assert snapshot["current_phase"] == "review"
+        assert snapshot["reason_code"] == "missing_approval"
+        assert snapshot["invariant"]["phase"] == "review"
+        assert "review checkpoint" in snapshot["reason"]

--- a/tests/test_vibeflow_e2e_modes.py
+++ b/tests/test_vibeflow_e2e_modes.py
@@ -120,6 +120,35 @@ def create_feature_list(project_root: Path, status: str) -> None:
 
 
 class TestVibeFlowModeE2E:
+    def test_detect_phase_cli_syncs_invariant_reason_to_runtime(self, tmp_path):
+        project_root = tmp_path / "invariant-runtime-project"
+        run_python(
+            ROOT / "scripts" / "init_project.py",
+            "invariant-runtime-project",
+            "--path",
+            project_root,
+            "--lang",
+            "python",
+        )
+
+        state = update_state(
+            project_root,
+            lambda data: data["checkpoints"].__setitem__("think", True),
+        )
+        write_text(project_root / state["artifacts"]["think"], "# Context\n\nInvariant runtime.\n")
+        create_workflow(project_root)
+        write_text(project_root / state["artifacts"]["plan"], "# Proposal\n\nWaiting approval.\n")
+
+        result = detect_phase(project_root)
+        assert result["phase"] == "plan"
+        assert result["reason_code"] == "missing_approval"
+        assert result["blocking_item"] == "plan"
+
+        runtime = read_json(project_root / ".vibeflow" / "runtime.json")
+        assert runtime["invariant"]["phase"] == "plan"
+        assert runtime["invariant"]["reason_code"] == "missing_approval"
+        assert "plan checkpoint" in runtime["invariant"]["reason"]
+
     def test_full_mode_end_to_end_flow(self, tmp_path):
         project_root = tmp_path / "full-mode-project"
         run_python(


### PR DESCRIPTION
## Summary
- add a minimal .vibeflow/policy.yaml phase policy file
- add scripts/validate_phase_invariants.py for machine-readable phase invariant validation
- wire invariant reason codes into phase detection, runtime sync, and dashboard stop messaging

## Testing
- pytest tests/test_vibeflow_v2.py -q
- pytest tests/test_vibeflow_e2e_modes.py -q
- pytest tests/test_vibeflow_dashboard.py -q
- pytest tests/test_detect_phase.py -q
- pytest tests/test_vibeflow_autopilot.py -q
- pytest tests/test_project_version.py -q

Closes #46