### PR TITLE
fix: register plugin command skills with correct version

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "vibeflow",
       "description": "VibeFlow skill library: full 16-phase workflow with plan reviews, safety guards, brainstorming, and office-hours.",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "source": "./",
       "author": {
         "name": "VibeFlow",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vibeflow",
   "description": "VibeFlow skill library: full 16-phase workflow with plan reviews, safety guards, brainstorming, and office-hours.",
-  "version": "1.0.0",
+  "version": "1.1.2",
   "author": {
     "name": "VibeFlow",
     "email": "vibeflow@example.com"

--- a/claude-code/install.ps1
+++ b/claude-code/install.ps1
@@ -140,17 +140,25 @@ $CleanVersion = $ResolvedRef -replace '^v', ''
 $VersionFile = Join-Path $TargetDir "VERSION"
 [System.IO.File]::WriteAllText($VersionFile, "$CleanVersion`n", (New-Object System.Text.UTF8Encoding($false)))
 
-# Update marketplace.json version
+# Update plugin.json + marketplace.json version
+$PluginJson = Join-Path $TargetDir ".claude-plugin\plugin.json"
 try {
+    if (Test-Path $PluginJson) {
+        $pluginContent = Get-Content $PluginJson -Raw | ConvertFrom-Json
+        $pluginContent.version = $CleanVersion
+        $pluginJson = $pluginContent | ConvertTo-Json -Depth 10
+        [System.IO.File]::WriteAllText($PluginJson, $pluginJson, (New-Object System.Text.UTF8Encoding($false)))
+    }
+
     $mpContent = Get-Content $MarketplaceJson -Raw | ConvertFrom-Json
     if ($mpContent.plugins -and $mpContent.plugins.Count -gt 0) {
         $mpContent.plugins[0].version = $CleanVersion
     }
     $mpJson = $mpContent | ConvertTo-Json -Depth 10
     [System.IO.File]::WriteAllText($MarketplaceJson, $mpJson, (New-Object System.Text.UTF8Encoding($false)))
-    Write-Info "Version updated to $CleanVersion"
+    Write-Info "Manifest versions updated to $CleanVersion"
 } catch {
-    Write-Info "Warning: Could not update marketplace.json version: $_"
+    Write-Info "Warning: Could not update plugin manifests: $_"
 }
 
 # =============================================================================

--- a/claude-code/install.sh
+++ b/claude-code/install.sh
@@ -194,7 +194,42 @@ CLEAN_VERSION="${RESOLVED_REF#v}"
 # Update VERSION file
 echo "$CLEAN_VERSION" > "${TARGET_DIR}/VERSION"
 
-# Update marketplace.json version
+# Update plugin.json + marketplace.json version
+PLUGIN_JSON="${TARGET_DIR}/.claude-plugin/plugin.json"
+
+update_plugin_version() {
+  local plugin_json="$1"
+  local version="$2"
+  if [[ -f "$plugin_json" ]]; then
+    if command -v jq >/dev/null 2>&1; then
+      local tmp_file="${plugin_json}.tmp"
+      jq --arg v "$version" '.version = $v' "$plugin_json" > "$tmp_file" && mv "$tmp_file" "$plugin_json"
+    elif command -v python3 >/dev/null 2>&1; then
+      python3 - "$plugin_json" "$version" <<'PYEOF'
+import json, sys
+path = sys.argv[1]
+version = sys.argv[2]
+with open(path) as f:
+    data = json.load(f)
+data["version"] = version
+with open(path, 'w') as f:
+    json.dump(data, f, indent=2)
+PYEOF
+    elif command -v python >/dev/null 2>&1; then
+      python - "$plugin_json" "$version" <<'PYEOF'
+import json, sys
+path = sys.argv[1]
+version = sys.argv[2]
+with open(path) as f:
+    data = json.load(f)
+data["version"] = version
+with open(path, 'w') as f:
+    json.dump(data, f, indent=2)
+PYEOF
+    fi
+  fi
+}
+
 update_marketplace_version() {
   local mp_json="$1"
   local version="$2"
@@ -231,8 +266,9 @@ PYEOF
   fi
 }
 
+update_plugin_version "$PLUGIN_JSON" "$CLEAN_VERSION"
 update_marketplace_version "$MARKETPLACE_JSON" "$CLEAN_VERSION"
-success "版本已更新为 ${CLEAN_VERSION}"
+success "Manifest 版本已更新为 ${CLEAN_VERSION}"
 
 # 6. Register in known_marketplaces.json
 info "注册 marketplace..."

--- a/skills/vibeflow-dashboard/SKILL.md
+++ b/skills/vibeflow-dashboard/SKILL.md
@@ -27,4 +27,4 @@ python scripts/run-vibeflow-dashboard.py --project-root .
 ## 说明
 
 - 这是 marketplace plugin 的正式命令入口，供 `/vibeflow-dashboard` 发现与加载
-- 仓库内的 `.claude/commands/vibeflow-dashboard.md` 继续保留，方便本地开发和兼容旧入口
+- 它属于用户可调用 skill，不是内部 skill

--- a/skills/vibeflow-status/SKILL.md
+++ b/skills/vibeflow-status/SKILL.md
@@ -22,4 +22,4 @@ python scripts/get-vibeflow-phase.py --project-root . --verbose
 ## 说明
 
 - 这是 marketplace plugin 的正式命令入口，供 `/vibeflow-status` 发现与加载
-- 仓库内的 `.claude/commands/vibeflow-status.md` 继续保留，方便本地开发和兼容旧入口
+- 它属于用户可调用 skill，不是内部 skill


### PR DESCRIPTION
## Summary
- keep `vibeflow-status` and `vibeflow-dashboard` as first-class user-invoked skills rather than internal-only skills or command shims
- fix Claude Code plugin manifest version drift so `plugin.json` and `marketplace.json` both report `1.1.2`
- update the Claude Code installers so both manifests are rewritten during install/upgrade, avoiding stale runtime registrations

## Verification
- `python scripts/test-vibeflow-setup.py --project-root validation/sample-priority-api --json`
- `powershell -ExecutionPolicy Bypass -File D:\AI\workspace\vibeflow\claude-code\debug-install.ps1`

## Notes
- this PR intentionally does not add `commands/` compatibility shims
- `vibeflow-status` and `vibeflow-dashboard` remain user-callable skills under `skills/<name>/SKILL.md`