### PR TITLE
fix: add missing frontmatter dashes and main entry command

### DIFF
--- a/.claude/commands/vibeflow-dashboard.md
+++ b/.claude/commands/vibeflow-dashboard.md
@@ -1,3 +1,4 @@
+---
 description: 启动 VibeFlow 本地看板，实时查看阶段、功能、产物和最近事件
 ---
 运行 `python scripts/run-vibeflow-dashboard.py --project-root .`，启动当前项目的本地 live dashboard。

--- a/.claude/commands/vibeflow-design.md
+++ b/.claude/commands/vibeflow-design.md
@@ -1,3 +1,4 @@
+---
 description: 开始设计阶段（vibeflow-design）
 ---
 调用 `skills/vibeflow-design/SKILL.md` 开始技术设计工作流。

--- a/.claude/commands/vibeflow-increment.md
+++ b/.claude/commands/vibeflow-increment.md
@@ -1,3 +1,4 @@
+---
 description: 处理增量请求（vibeflow increment）
 ---
 运行 `python scripts/increment-handler.py --project-root .` 处理所有待处理的增量请求。

--- a/.claude/commands/vibeflow-init.md
+++ b/.claude/commands/vibeflow-init.md
@@ -1,3 +1,4 @@
+---
 description: 初始化 VibeFlow 项目脚手架
 ---
 运行 `python scripts/init_project.py <project-name> --path .` 初始化项目。使用项目目录名作为 project-name。

--- a/.claude/commands/vibeflow-learn.md
+++ b/.claude/commands/vibeflow-learn.md
@@ -1,3 +1,4 @@
+---
 description: 启动独立学习流（vibeflow-learn）
 ---
 调用 `skills/vibeflow-learn/SKILL.md` 开始独立学习、资料消化与研究写作流程。

--- a/.claude/commands/vibeflow-plan.md
+++ b/.claude/commands/vibeflow-plan.md
@@ -1,3 +1,4 @@
+---
 description: 开始 Plan 阶段（已合并到 Spark）
 ---
 vibeflow-plan 已合并到 vibeflow-spark。使用 `/vibeflow-spark` 启动。

--- a/.claude/commands/vibeflow-requirements.md
+++ b/.claude/commands/vibeflow-requirements.md
@@ -1,3 +1,4 @@
+---
 description: 开始需求阶段（vibeflow-requirements）
 ---
 调用 `skills/vibeflow-requirements/SKILL.md` 开始需求收集工作流。

--- a/.claude/commands/vibeflow-st.md
+++ b/.claude/commands/vibeflow-st.md
@@ -1,3 +1,4 @@
+---
 description: 开始系统测试阶段（vibeflow-test-system）
 ---
 调用 `skills/vibeflow-test-system/SKILL.md` 开始系统测试工作流。

--- a/.claude/commands/vibeflow-status.md
+++ b/.claude/commands/vibeflow-status.md
@@ -1,3 +1,4 @@
+---
 description: 查看 VibeFlow 项目当前状态（阶段、进度、待处理项）
 ---
 运行 `python scripts/get-vibeflow-phase.py --project-root . --verbose`，读取 `.vibeflow/phase-history.json`、`.vibeflow/work-config.json`、`feature-list.json`，输出格式化的状态摘要。

--- a/.claude/commands/vibeflow-value-review.md
+++ b/.claude/commands/vibeflow-value-review.md
@@ -1,3 +1,4 @@
+---
 description: 进行 CEO 视角的商业价值评估（plan-value-review）
 ---
 调用 `skills/vibeflow-plan-value-review/SKILL.md` 执行价值审查。

--- a/.claude/commands/vibeflow-work.md
+++ b/.claude/commands/vibeflow-work.md
@@ -1,3 +1,4 @@
+---
 description: 从 Build 阶段开始自动继续后续链路
 ---
 先运行 `python scripts/get-vibeflow-phase.py --project-root . --json` 确认当前阶段。

--- a/.claude/commands/vibeflow.md
+++ b/.claude/commands/vibeflow.md
@@ -1,0 +1,8 @@
+---
+description: VibeFlow框架入口。运行 /vibeflow 开始新项目或继续现有工作流。
+---
+调用 `skills/vibeflow/SKILL.md` 进入 VibeFlow 框架。
+
+- 首次进入新项目：会先让用户选择 `Full Mode` 或 `Quick Mode`
+- 继续已有项目：直接沿用 `.vibeflow/state.json` 中的 mode
+- 直达 Quick Mode：使用 `/vibeflow-quick`


### PR DESCRIPTION
- Add --- frontmatter prefix to 11 command files
- Add missing vibeflow.md main entry command
- Marketplace plugin commands require .claude/commands/ with proper frontmatter

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
